### PR TITLE
Add pre-commit hooks and cabal-gild integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist-newstyle
 /cabal.project.local
 .envrc
+.pre-commit-config.yaml

--- a/Contributing.md
+++ b/Contributing.md
@@ -101,6 +101,16 @@ To generate documentation run
 cabal haddock all
 ```
 
+## Pre-commit hooks
+
+This project uses pre-commit hooks to ensure code quality and consistency. The hooks include:
+
+- **fourmolu**: Haskell code formatting
+- **nixfmt**: Nix file formatting  
+- **cabal-gild**: Cabal file formatting
+
+These hooks are automatically configured by the Nix shell environment. To use them, simply make your changes and commit as usual. The hooks will run automatically before each commit.
+
 ## How to Contribute
 
 1. **Fork the repository** and create your branch from `main`.

--- a/flake.lock
+++ b/flake.lock
@@ -100,6 +100,22 @@
         "type": "github"
       }
     },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -115,6 +131,27 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -586,6 +623,28 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1757239681,
+        "narHash": "sha256-E9spYi9lxm2f1zWQLQ7xQt8Xs2nWgr1T4QM7ZjLFphM=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "ab82ab08d6bf74085bd328de2a8722c12d97bd9d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -593,7 +652,8 @@
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-unstable"
-        ]
+        ],
+        "pre-commit-hooks": "pre-commit-hooks"
       }
     },
     "stackage": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,11 @@
   inputs.haskellNix.url = "github:input-output-hk/haskell.nix";
   inputs.nixpkgs.follows = "haskellNix/nixpkgs-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  outputs = { self, nixpkgs, flake-utils, haskellNix }:
+  inputs.pre-commit-hooks = {
+    url = "github:cachix/pre-commit-hooks.nix";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+  outputs = { self, nixpkgs, flake-utils, haskellNix, pre-commit-hooks }:
     let
       supportedSystems =
         [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
             cardanoCanonicalLedger = final.haskell-nix.hix.project {
               src = ./.;
               # uncomment with your current system for `nix flake show` to work:
-              evalSystem = "x86_64-linux";
+              # evalSystem = "x86_64-linux";
             };
           })
         ];

--- a/nix/hix.nix
+++ b/nix/hix.nix
@@ -9,6 +9,7 @@
     hlint = "latest";
     fourmolu = "latest";
     weeder = "latest";
+    cabal-gild = "latest";
   };
 
   # Non-Haskell shell tools go here


### PR DESCRIPTION
Integrate pre-commit hooks for formatting and linting tools, and add cabal-gild to the shell tools.