### PR TITLE
Add support for haskell-language-server-wrapper

### DIFF
--- a/nix/hix.nix
+++ b/nix/hix.nix
@@ -13,5 +13,10 @@
   };
 
   # Non-Haskell shell tools go here
-  shell.buildInputs = with pkgs; [ nixfmt-classic ];
+  shell.buildInputs = let
+    # Add this for editors which expect to use hls-wrapper
+    hls-wrapper = pkgs.writeShellScriptBin "haskell-language-server-wrapper" ''
+      exec haskell-language-server "$@"
+    '';
+  in with pkgs; [ nixfmt-classic hls-wrapper ];
 }


### PR DESCRIPTION
Some editors (helix!) expect to find `haskell-language-server-wrapper` binary. This commit makes that available and pointing to the regular haskell-language-server.