### PR TITLE
Add scls-cbor package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,5 @@
 packages:
   scls-format
+  scls-cbor
   scls-cddl
   merkle-tree-incremental

--- a/scls-cbor/CHANGELOG.md
+++ b/scls-cbor/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for scls-cbor
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/scls-cbor/LICENSE
+++ b/scls-cbor/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/scls-cbor/scls-cbor.cabal
+++ b/scls-cbor/scls-cbor.cabal
@@ -1,0 +1,35 @@
+cabal-version: 3.14
+name: scls-cbor
+version: 0.1.0.0
+synopsis: CBOR utilities for the Cardano Canonical Ledger State
+-- description:
+homepage: https://github.com/tweag/cardano-canonical-ledger
+license: Apache-2.0
+license-file: LICENSE
+author: Tweag IO Team
+maintainer: cardano-scls@tweag.io
+-- copyright:
+category: Data
+build-type: Simple
+extra-doc-files: CHANGELOG.md
+
+-- extra-source-files:
+common warnings
+  ghc-options: -Wall
+
+library
+  import: warnings
+  exposed-modules:
+    Cardano.SCLS.CBOR.Canonical
+
+  -- other-modules:
+  -- other-extensions:
+  build-depends:
+    base ^>=4.20.1.0,
+    bytestring,
+    cborg,
+    containers,
+    scls-format
+
+  hs-source-dirs: src
+  default-language: GHC2021

--- a/scls-cbor/src/Cardano/SCLS/CBOR/Canonical.hs
+++ b/scls-cbor/src/Cardano/SCLS/CBOR/Canonical.hs
@@ -1,0 +1,240 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+
+{- | Canonical CBOR representation
+
+This module contains only instances for cases where there is a direct and
+unambiguous instance that will remain the same across all versions. For
+example, since there are multiple possible ways to encode 'Maybe' we do
+not provide an instance here - it is better to specify the precise encoding
+when defining the instances for specific types.
+-}
+module Cardano.SCLS.CBOR.Canonical where
+
+import Cardano.SCLS.Internal.Version (Version)
+import Codec.CBOR.ByteArray.Sliced qualified as BAS
+import Codec.CBOR.Encoding (Encoding)
+import Codec.CBOR.Encoding qualified as E
+import Data.Array.Byte qualified as Prim
+import Data.ByteString (ByteString)
+import Data.ByteString.Short (ShortByteString (SBS))
+import Data.ByteString.Short qualified as SBS
+import Data.Int
+import Data.Map qualified as Map
+import Data.Sequence qualified as Seq
+import Data.Word
+
+-- | Encode data to CBOR corresponding with the SCLS format.
+class ToCanonicalCBOR (v :: Version) a where
+  -- | Encode to canonical CBOR at a given version
+  toCanonicalCBOR :: proxy v -> a -> Encoding
+
+--------------------------------------------------------------------------------
+-- Encoding etc
+--------------------------------------------------------------------------------
+
+instance ToCanonicalCBOR v Encoding where
+  toCanonicalCBOR _ = id
+
+--------------------------------------------------------------------------------
+-- Primitive types
+--------------------------------------------------------------------------------
+
+instance ToCanonicalCBOR v () where
+  toCanonicalCBOR _ = const E.encodeNull
+
+instance ToCanonicalCBOR v Bool where
+  toCanonicalCBOR _ = E.encodeBool
+
+--------------------------------------------------------------------------------
+-- Numeric data
+--------------------------------------------------------------------------------
+
+instance ToCanonicalCBOR v Integer where
+  toCanonicalCBOR _ = E.encodeInteger
+
+instance ToCanonicalCBOR v Word where
+  toCanonicalCBOR _ = E.encodeWord
+
+instance ToCanonicalCBOR v Word8 where
+  toCanonicalCBOR _ = E.encodeWord8
+
+instance ToCanonicalCBOR v Word16 where
+  toCanonicalCBOR _ = E.encodeWord16
+
+instance ToCanonicalCBOR v Word32 where
+  toCanonicalCBOR _ = E.encodeWord32
+
+instance ToCanonicalCBOR v Word64 where
+  toCanonicalCBOR _ = E.encodeWord64
+
+instance ToCanonicalCBOR v Int where
+  toCanonicalCBOR _ = E.encodeInt
+
+instance ToCanonicalCBOR v Int32 where
+  toCanonicalCBOR _ = E.encodeInt32
+
+instance ToCanonicalCBOR v Int64 where
+  toCanonicalCBOR _ = E.encodeInt64
+
+--------------------------------------------------------------------------------
+-- Bytes
+--------------------------------------------------------------------------------
+
+instance ToCanonicalCBOR v ByteString where
+  toCanonicalCBOR _ = E.encodeBytes
+
+instance ToCanonicalCBOR v SBS.ShortByteString where
+  toCanonicalCBOR _ sbs@(SBS ba) =
+    E.encodeByteArray $ BAS.SBA (Prim.ByteArray ba) 0 (SBS.length sbs)
+
+--------------------------------------------------------------------------------
+-- Tuples
+--------------------------------------------------------------------------------
+
+instance
+  (ToCanonicalCBOR v a, ToCanonicalCBOR v b) =>
+  ToCanonicalCBOR v (a, b)
+  where
+  toCanonicalCBOR v (a, b) =
+    E.encodeListLen 2
+      <> toCanonicalCBOR v a
+      <> toCanonicalCBOR v b
+
+instance
+  ( ToCanonicalCBOR v a
+  , ToCanonicalCBOR v b
+  , ToCanonicalCBOR v c
+  ) =>
+  ToCanonicalCBOR v (a, b, c)
+  where
+  toCanonicalCBOR v (a, b, c) =
+    E.encodeListLen 3
+      <> toCanonicalCBOR v a
+      <> toCanonicalCBOR v b
+      <> toCanonicalCBOR v c
+
+instance
+  ( ToCanonicalCBOR v a
+  , ToCanonicalCBOR v b
+  , ToCanonicalCBOR v c
+  , ToCanonicalCBOR v d
+  ) =>
+  ToCanonicalCBOR v (a, b, c, d)
+  where
+  toCanonicalCBOR v (a, b, c, d) =
+    E.encodeListLen 4
+      <> toCanonicalCBOR v a
+      <> toCanonicalCBOR v b
+      <> toCanonicalCBOR v c
+      <> toCanonicalCBOR v d
+
+instance
+  ( ToCanonicalCBOR v a
+  , ToCanonicalCBOR v b
+  , ToCanonicalCBOR v c
+  , ToCanonicalCBOR v d
+  , ToCanonicalCBOR v e
+  ) =>
+  ToCanonicalCBOR v (a, b, c, d, e)
+  where
+  toCanonicalCBOR v (a, b, c, d, e) =
+    E.encodeListLen 5
+      <> toCanonicalCBOR v a
+      <> toCanonicalCBOR v b
+      <> toCanonicalCBOR v c
+      <> toCanonicalCBOR v d
+      <> toCanonicalCBOR v e
+
+instance
+  ( ToCanonicalCBOR v a
+  , ToCanonicalCBOR v b
+  , ToCanonicalCBOR v c
+  , ToCanonicalCBOR v d
+  , ToCanonicalCBOR v e
+  , ToCanonicalCBOR v f
+  ) =>
+  ToCanonicalCBOR v (a, b, c, d, e, f)
+  where
+  toCanonicalCBOR v (a, b, c, d, e, f) =
+    E.encodeListLen 6
+      <> toCanonicalCBOR v a
+      <> toCanonicalCBOR v b
+      <> toCanonicalCBOR v c
+      <> toCanonicalCBOR v d
+      <> toCanonicalCBOR v e
+      <> toCanonicalCBOR v f
+
+instance
+  ( ToCanonicalCBOR v a
+  , ToCanonicalCBOR v b
+  , ToCanonicalCBOR v c
+  , ToCanonicalCBOR v d
+  , ToCanonicalCBOR v e
+  , ToCanonicalCBOR v f
+  , ToCanonicalCBOR v g
+  ) =>
+  ToCanonicalCBOR v (a, b, c, d, e, f, g)
+  where
+  toCanonicalCBOR v (a, b, c, d, e, f, g) =
+    E.encodeListLen 7
+      <> toCanonicalCBOR v a
+      <> toCanonicalCBOR v b
+      <> toCanonicalCBOR v c
+      <> toCanonicalCBOR v d
+      <> toCanonicalCBOR v e
+      <> toCanonicalCBOR v f
+      <> toCanonicalCBOR v g
+
+instance
+  ( ToCanonicalCBOR v a
+  , ToCanonicalCBOR v b
+  , ToCanonicalCBOR v c
+  , ToCanonicalCBOR v d
+  , ToCanonicalCBOR v e
+  , ToCanonicalCBOR v f
+  , ToCanonicalCBOR v g
+  , ToCanonicalCBOR v h
+  ) =>
+  ToCanonicalCBOR v (a, b, c, d, e, f, g, h)
+  where
+  toCanonicalCBOR v (a, b, c, d, e, f, g, h) =
+    E.encodeListLen 8
+      <> toCanonicalCBOR v a
+      <> toCanonicalCBOR v b
+      <> toCanonicalCBOR v c
+      <> toCanonicalCBOR v d
+      <> toCanonicalCBOR v e
+      <> toCanonicalCBOR v f
+      <> toCanonicalCBOR v g
+      <> toCanonicalCBOR v h
+
+--------------------------------------------------------------------------------
+-- Lists
+--------------------------------------------------------------------------------
+
+-- | We always encode lists with the indefinite length encoding.
+instance (ToCanonicalCBOR v a) => ToCanonicalCBOR v [a] where
+  toCanonicalCBOR v xs =
+    E.encodeListLenIndef
+      <> foldr (\x r -> toCanonicalCBOR v x <> r) E.encodeBreak xs
+
+instance (ToCanonicalCBOR v a) => ToCanonicalCBOR v (Seq.Seq a) where
+  toCanonicalCBOR v xs =
+    E.encodeListLenIndef
+      <> foldr (\x r -> toCanonicalCBOR v x <> r) E.encodeBreak xs
+
+--------------------------------------------------------------------------------
+-- Maps
+--------------------------------------------------------------------------------
+
+-- | We always encode maps with the indefinite length encoding.
+instance
+  (ToCanonicalCBOR v k, ToCanonicalCBOR v val) =>
+  ToCanonicalCBOR v (Map.Map k val)
+  where
+  toCanonicalCBOR v m = E.encodeMapLenIndef <>
+    Map.foldrWithKey
+      (\k val b -> toCanonicalCBOR v k <> toCanonicalCBOR v val <> b)
+      E.encodeBreak
+      m

--- a/scls-cddl/scls-cddl.cabal
+++ b/scls-cddl/scls-cddl.cabal
@@ -23,29 +23,6 @@ common warnings
 
 library
   import: warnings
-  default-language: GHC2021
-  exposed-modules: MyLib
-  -- other-modules:
-  -- other-extensions:
-  build-depends: base >=4.18 && <4.22
-  hs-source-dirs: src
-
-executable gen-cddl
-  import: warnings
-  default-language: GHC2021
-  hs-source-dirs: gen-cddl
-  main-is: Main.hs
-  build-depends:
-    base >=4.18 && <5,
-    containers >=0.6,
-    cuddle >= 0.5,
-    filepath >=1.4,
-    prettyprinter,
-    scls-cddl:cddl-src
-
-library cddl-src
-  import: warnings
-  visibility: public
   exposed-modules:
     Cardano.SCLS.CDDL
 
@@ -64,14 +41,15 @@ library cddl-src
 
   default-language: GHC2021
 
-test-suite scls-cddl-test
+executable gen-cddl
   import: warnings
   default-language: GHC2021
-  -- other-modules:
-  -- other-extensions:
-  type: exitcode-stdio-1.0
-  hs-source-dirs: test
+  hs-source-dirs: gen-cddl
   main-is: Main.hs
   build-depends:
     base >=4.18 && <5,
+    containers >=0.6,
+    cuddle >=0.5,
+    filepath >=1.4,
+    prettyprinter,
     scls-cddl

--- a/scls-cddl/src/MyLib.hs
+++ b/scls-cddl/src/MyLib.hs
@@ -1,4 +1,0 @@
-module MyLib (someFunc) where
-
-someFunc :: IO ()
-someFunc = putStrLn "someFunc"

--- a/scls-cddl/test/Main.hs
+++ b/scls-cddl/test/Main.hs
@@ -1,6 +1,0 @@
-module Main (main) where
-
-import qualified MyLib
-
-main :: IO ()
-main = const (putStrLn "Test suite not yet implemented.") (MyLib.someFunc)

--- a/scls-format/scls-format.cabal
+++ b/scls-format/scls-format.cabal
@@ -114,7 +114,7 @@ test-suite scls-format-test
     cuddle >=0.5,
     filepath,
     random >=1.2,
-    scls-cddl:{cddl-src},
+    scls-cddl,
     scls-format,
     streaming >=0.2.4.0,
     temporary,


### PR DESCRIPTION
This contains the definition of 'ToCanonicalCBOR'
which can be used downstream to define the encoding
for various types to the SCLS canonical CBOR format.

We define instances for many major types, but try
to avoid cases where there may be ambiguity.

For maps and lists, we choose the indefinite length
encoding. While this is not always the most compact
encoding, it simplifies the description of what
tools should write to adhere to the SCLS
specification.

I had originally intended this to live in `scls-cddl` but we hit issues with circular references, so going with a separate package seems fine.