### PR TITLE
Add tests for ChunksBuilder

### DIFF
--- a/scls-format/scls-format.cabal
+++ b/scls-format/scls-format.cabal
@@ -120,12 +120,16 @@ test-suite scls-format-test
   main-is: Main.hs
   build-depends:
     HUnit,
+    QuickCheck,
     base >=4.18 && <5,
     bytestring,
     cborg >=0.2,
     containers,
     cuddle >=0.5,
     filepath,
+    hspec,
+    hspec-contrib,
+    hspec-expectations,
     merkle-tree-incremental,
     primitive,
     random >=1.2,

--- a/scls-format/scls-format.cabal
+++ b/scls-format/scls-format.cabal
@@ -111,7 +111,9 @@ executable example-extract-by-ns
 test-suite scls-format-test
   import: warnings
   default-language: GHC2021
-  -- other-modules:
+  other-modules:
+    ChunksBuilderSpec
+
   -- other-extensions:
   type: exitcode-stdio-1.0
   hs-source-dirs: test
@@ -119,11 +121,13 @@ test-suite scls-format-test
   build-depends:
     HUnit,
     base >=4.18 && <5,
+    bytestring,
     cborg >=0.2,
     containers,
     cuddle >=0.5,
     filepath,
     merkle-tree-incremental,
+    primitive,
     random >=1.2,
     scls-cddl,
     scls-format,

--- a/scls-format/src/Cardano/SCLS/Internal/Record/Chunk.hs
+++ b/scls-format/src/Cardano/SCLS/Internal/Record/Chunk.hs
@@ -32,7 +32,7 @@ data ChunkFormat
     ChunkFormatZstd
   | -- | Entries are individually compressed with seekable zstd
     ChunkFormatZstdE
-  deriving (Show)
+  deriving (Show, Eq)
 
 instance Binary ChunkFormat where
   put ChunkFormatRaw = putWord8 0

--- a/scls-format/test/ChunksBuilderSpec.hs
+++ b/scls-format/test/ChunksBuilderSpec.hs
@@ -1,0 +1,208 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module ChunksBuilderSpec (chunksBuilderTests) where
+
+import Cardano.SCLS.Internal.Hash (Digest (..))
+import Cardano.SCLS.Internal.Record.Chunk (ChunkFormat (ChunkFormatRaw))
+import Cardano.SCLS.Internal.Serializer.ChunksBuilder.InMemory
+import Cardano.SCLS.Internal.Serializer.MemPack (RawBytes (..))
+import Data.ByteString qualified as BS
+import Data.Maybe (isJust, isNothing)
+import Data.Primitive.ByteArray (sizeofByteArray)
+import Test.HUnit
+
+chunksBuilderTests :: Test
+chunksBuilderTests =
+  TestLabel "ChunksBuilder.InMemory Tests" $
+    TestList
+      [ bufferBoundaryTests
+      , finalizationTests
+      , edgeCaseTests
+      ]
+
+bufferBoundaryTests :: Test
+bufferBoundaryTests =
+  TestLabel "Buffer Boundary Tests" $
+    TestList
+      [ testFitsBuffer
+      , testExactBoundary
+      , testOversizedEmpty
+      , testOversizedNonEmpty
+      ]
+
+finalizationTests :: Test
+finalizationTests =
+  TestLabel "Finalization Tests" $
+    TestList
+      [ testFinalizeEmpty
+      , testFinalizeNonEmpty
+      ]
+
+edgeCaseTests :: Test
+edgeCaseTests =
+  TestLabel "Edge Case Tests" $ TestList [testMultipleBoundaryCrossings]
+
+-- Test adding data that fits within buffer capacity
+testFitsBuffer :: Test
+testFitsBuffer = TestCase $ do
+  let bufferLength = 100
+  machine <- mkMachine bufferLength ChunkFormatRaw
+  let smallData = RawBytes (BS.replicate 20 0x42)
+  (machine', chunks) <- interpretCommand machine (Append smallData)
+  assertEqual "Should not emit chunks when data fits" 0 (length chunks)
+
+  let mediumData = RawBytes (BS.replicate 30 0x43)
+  (_machine, chunks') <- interpretCommand machine' (Append mediumData)
+  assertEqual "Should not emit chunks when accumulated data fits" 0 (length chunks')
+
+-- Test adding records that exactly fill the buffer
+testExactBoundary :: Test
+testExactBoundary = TestCase $ do
+  let bufferLength = 100
+  machine <- mkMachine bufferLength ChunkFormatRaw
+  let chunkDataLength = bufferLength - 4 -- 4 bytes for length prefix
+  let exactFitData = RawBytes (BS.replicate chunkDataLength 0x44)
+  (machine', chunks) <- interpretCommand machine (Append exactFitData)
+  assertEqual "Should not emit chunks when data exactly fits" 0 (length chunks)
+
+  -- Adding one more byte should trigger emission
+  let oneByte = RawBytes (BS.replicate 1 0x45)
+  (_machine, chunks') <- interpretCommand machine' (Append oneByte)
+  assertEqual "Should emit exactly one chunk" 1 (length chunks')
+  case chunks' of
+    [chunk] -> do
+      assertEqual "Chunk should have correct entries count" 1 (chunkItemEntriesCount chunk)
+      assertBool "Chunk should use correct format" (case chunkItemFormat chunk of ChunkFormatRaw -> True; _ -> False)
+      assertEqual "Chunk data should have correct size" (chunkDataLength + 4) (sizeofByteArray $ chunkItemData chunk)
+    _ -> assertFailure "Expected exactly one chunk"
+
+-- Test adding a record larger than buffer when buffer is empty
+testOversizedEmpty :: Test
+testOversizedEmpty = TestCase $ do
+  let bufferLength = 50
+  machine <- mkMachine bufferLength ChunkFormatRaw
+  -- 50-3+4=51 bytes total with prefix, exceeding buffer
+  let largeDataLength = bufferLength - 3
+  let largeData = RawBytes (BS.replicate largeDataLength 0x46)
+  (_machine, chunks) <- interpretCommand machine (Append largeData)
+  -- In this case the implementation emits both the frozen buffer
+  -- (which is empty in this case) and the oversized chunk
+  -- TODO: consider changing this behavior to emit only the oversized chunk
+  assertEqual "Should emit exactly two chunks for oversized data" 2 (length chunks)
+  case chunks of
+    [emptyChunk, oversizedChunk] -> do
+      -- First chunk should be empty since buffer was empty
+      assertEqual "Empty chunk should have zero entries" 0 (chunkItemEntriesCount emptyChunk)
+      -- Second chunk should contain the oversized data
+      assertEqual "Oversized chunk should have correct entries count" 1 (chunkItemEntriesCount oversizedChunk)
+      assertEqual "Oversized chunk data should match input size" (largeDataLength + 4) (sizeofByteArray $ chunkItemData oversizedChunk)
+    _ -> assertFailure "Expected exactly two chunks"
+
+-- Test adding a record larger than buffer when buffer is not empty
+testOversizedNonEmpty :: Test
+testOversizedNonEmpty = TestCase $ do
+  let bufferLength = 50
+  machine <- mkMachine bufferLength ChunkFormatRaw
+  -- Add data that fits first
+  let smallDataLength = bufferLength - 40
+  let smallData = RawBytes (BS.replicate smallDataLength 0x47)
+  (machine', chunks) <- interpretCommand machine (Append smallData)
+  assertEqual "Should not emit chunks for small data" 0 (length chunks)
+
+  -- Now add oversized data
+  -- 50-3+4=51 bytes total with prefix, exceeding buffer
+  let largeDataLength = bufferLength - 3
+  let largeData = RawBytes (BS.replicate largeDataLength 0x48)
+  (_machine, chunks') <- interpretCommand machine' (Append largeData)
+  assertEqual "Should emit exactly two chunks" 2 (length chunks')
+  case chunks' of
+    [firstChunk, secondChunk] -> do
+      -- First chunk should contain the small data
+      assertEqual "First chunk should have correct entries count" 1 (chunkItemEntriesCount firstChunk)
+      assertEqual "First chunk data should match small input size" (smallDataLength + 4) (sizeofByteArray $ chunkItemData firstChunk)
+      -- Second chunk should contain the large data
+      assertEqual "Second chunk should have correct entries count" 1 (chunkItemEntriesCount secondChunk)
+      assertEqual "Second chunk data should match large input size" (largeDataLength + 4) (sizeofByteArray $ chunkItemData secondChunk)
+    _ -> assertFailure "Expected exactly two chunks"
+
+-- Test finalization when buffer is empty
+testFinalizeEmpty :: Test
+testFinalizeEmpty = TestCase $ do
+  let bufferLength = 10
+  machine <- mkMachine bufferLength ChunkFormatRaw
+  (digest, maybeChunk) <- interpretCommand machine Finalize
+  assertBool "Should not emit chunk for empty buffer" (isNothing maybeChunk)
+  -- Digest should still be computed (even if empty)
+  assertBool "Digest should be present" (case digest of Digest _ -> True)
+
+-- Test finalization when buffer contains data
+testFinalizeNonEmpty :: Test
+testFinalizeNonEmpty = TestCase $ do
+  let bufferLength = 100
+  machine <- mkMachine bufferLength ChunkFormatRaw
+  let testDataLength = bufferLength - 30
+  let testData = RawBytes (BS.replicate testDataLength 0x49)
+  (machine', chunks) <- interpretCommand machine (Append testData)
+  assertEqual "Should not emit chunks before finalization" 0 (length chunks)
+
+  (_digest, maybeChunk) <- interpretCommand machine' Finalize
+  case maybeChunk of
+    Just chunk -> do
+      assertEqual "Finalized chunk should have correct entries count" 1 (chunkItemEntriesCount chunk)
+      assertBool "Finalized chunk should use correct format" (case chunkItemFormat chunk of ChunkFormatRaw -> True; _ -> False)
+      assertEqual "Finalized chunk data should have correct size" (testDataLength + 4) (sizeofByteArray $ chunkItemData chunk)
+    Nothing -> assertFailure "Expected chunk on finalization with data"
+
+-- Test multiple boundary crossings
+testMultipleBoundaryCrossings :: Test
+testMultipleBoundaryCrossings = TestCase $ do
+  let bufferLength = 50
+  machine <- mkMachine bufferLength ChunkFormatRaw
+  -- Add data that will cause multiple boundary crossings
+  -- 26 bytes total with prefix
+  let dataChunk1Length = 22
+  let dataChunk1 = RawBytes (BS.replicate dataChunk1Length 0x4A)
+  -- 14 bytes total with prefix
+  let dataChunk2Length = 10
+  let dataChunk2 = RawBytes (BS.replicate dataChunk2Length 0x4A)
+
+  (machine1, chunks1) <- interpretCommand machine (Append dataChunk1)
+  -- First add: 0 + 26 = 26, fits (total = 26)
+  assertEqual "First addition should not emit" 0 (length chunks1)
+
+  (machine2, chunks2) <- interpretCommand machine1 (Append dataChunk1)
+  -- Second add: 26 + 26 = 52 > 50, so emit buffer with one entry (total = 26)
+  -- Start new buffer with new data (total = 26)
+  case chunks2 of
+    [chunk] -> do
+      assertEqual "Second addition should emit one chunk with one entry" 1 (chunkItemEntriesCount chunk)
+      assertEqual "Chunk data size should match" (dataChunk1Length + 4) (sizeofByteArray $ chunkItemData chunk)
+    l -> assertEqual "Second addition should emit one chunk" 1 (length l)
+
+  (machine3, chunks3) <- interpretCommand machine2 (Append dataChunk2)
+  -- Third add: 26 + 14 = 40, fits (total = 40)
+  assertEqual "Third addition should not emit" 0 (length chunks3)
+
+  (machine4, chunks4) <- interpretCommand machine3 (Append dataChunk2)
+  -- Fourth add: 40 + 14 = 54 > 50, so emit buffer with two entries (total = 40)
+  -- Start new buffer with new data (total = 14)
+  case chunks4 of
+    [chunk] -> do
+      assertEqual "Fourth addition should emit one chunk with two entries" 2 (chunkItemEntriesCount chunk)
+      assertEqual "Chunk data size should match" (dataChunk1Length + 4 + dataChunk2Length + 4) (sizeofByteArray $ chunkItemData chunk)
+    l -> assertEqual "Fourth addition should emit one chunk" 1 (length l)
+
+  (machine5, chunks5) <- interpretCommand machine4 (Append dataChunk2)
+  -- Fifth add: 14 + 14 = 28, fits (total = 28)
+  assertEqual "Fifth addition should not emit" 0 (length chunks5)
+
+  (machine6, chunks6) <- interpretCommand machine5 (Append dataChunk2)
+  -- Sixth add: 28 + 14 = 42, fits (total = 42)
+  assertEqual "Sixth addition should not emit" 0 (length chunks6)
+
+  (_digest, finalChunk) <- interpretCommand machine6 Finalize
+  case finalChunk of
+    Just chunk -> do
+      assertEqual "Final chunk should have three entries" 3 (chunkItemEntriesCount chunk)
+      assertEqual "Final chunk data size should match" ((dataChunk2Length + 4) * 3) (sizeofByteArray $ chunkItemData chunk)
+    Nothing -> assertFailure "Expected final chunk on finalization"

--- a/scls-format/test/ChunksBuilderSpec.hs
+++ b/scls-format/test/ChunksBuilderSpec.hs
@@ -1,208 +1,214 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module ChunksBuilderSpec (chunksBuilderTests) where
 
 import Cardano.SCLS.Internal.Hash (Digest (..))
-import Cardano.SCLS.Internal.Record.Chunk (ChunkFormat (ChunkFormatRaw))
+import Cardano.SCLS.Internal.Record.Chunk
 import Cardano.SCLS.Internal.Serializer.ChunksBuilder.InMemory
-import Cardano.SCLS.Internal.Serializer.MemPack (RawBytes (..))
+import Cardano.SCLS.Internal.Serializer.MemPack
+import Control.Monad
 import Data.ByteString qualified as BS
-import Data.Maybe (isJust, isNothing)
-import Data.Primitive.ByteArray (sizeofByteArray)
+import Data.Maybe
+import Data.Primitive.ByteArray
 import Test.HUnit
+import Test.Hspec
+import Test.Hspec.Expectations.Contrib
+import Test.Hspec.QuickCheck
+import Test.QuickCheck
 
-chunksBuilderTests :: Test
+chunksBuilderTests :: Spec
 chunksBuilderTests =
-  TestLabel "ChunksBuilder.InMemory Tests" $
-    TestList
-      [ bufferBoundaryTests
-      , finalizationTests
-      , edgeCaseTests
-      ]
+  describe "ChunksBuilder.InMemory" $ do
+    bufferBoundaryTests
+    finalizationTests
 
-bufferBoundaryTests :: Test
+bufferFittingChunks :: Gen (Int, [Int])
+bufferFittingChunks = do
+  chunkCount <- choose (1, 10)
+  -- Buffer size between chunkCount*4 (minimum for empty chunks) and 200 bytes
+  bufferSize <- choose (chunkCount * 4, 200)
+  -- Each chunk size is chosen to ensure total fits in buffer
+  let maxChunkSize = bufferSize `div` chunkCount - 4
+  chunkSizes <- vectorOf chunkCount (choose (0, maxChunkSize))
+  return (bufferSize, chunkSizes)
+
+bufferFillingChunks :: Gen (Int, [Int])
+bufferFillingChunks = do
+  bufferSize <- choose (20, 200)
+  chunkSizes <- fillChunkSizes [] bufferSize
+  return (bufferSize, chunkSizes)
+ where
+  -- Generate chunks that will exactly fill the buffer
+  fillChunkSizes acc 0 = return (reverse acc)
+  fillChunkSizes acc remaining = do
+    let maxChunkSize = remaining - 4
+    if maxChunkSize < 8
+      then return (maxChunkSize : acc) -- Last chunk to fill exactly
+      else do
+        chunkSize <- choose (0, maxChunkSize - 4)
+        fillChunkSizes (chunkSize : acc) (remaining - (chunkSize + 4))
+
+bufferFittingAndOversizedChunks :: Gen (Int, Int, Int)
+bufferFittingAndOversizedChunks = do
+  bufferLength <- choose (50, 200)
+  smallDataLength <- choose (1, bufferLength - 4)
+  largeDataLength <- choose (bufferLength - 3, bufferLength + 100)
+  return (bufferLength, smallDataLength, largeDataLength)
+
+foldAppendChunks :: BuilderMachine -> [RawBytes] -> IO (BuilderMachine, [ChunkItem])
+foldAppendChunks machine =
+  foldM
+    ( \(machine', acc) chunkData -> do
+        (machine'', chunks') <- interpretCommand machine' (Append chunkData)
+        return (machine'', acc ++ chunks')
+    )
+    (machine, [])
+
+bufferBoundaryTests :: Spec
 bufferBoundaryTests =
-  TestLabel "Buffer Boundary Tests" $
-    TestList
-      [ testFitsBuffer
-      , testExactBoundary
-      , testOversizedEmpty
-      , testOversizedNonEmpty
-      ]
+  describe "Buffer Boundary Tests" $ do
+    prop "should not emit chunks when data fits" $
+      forAll bufferFittingChunks $ \(bufferLength, chunkLengths) -> do
+        machine <- mkMachine bufferLength ChunkFormatRaw
+        (_machine, emittedChunks) <-
+          foldAppendChunks machine (map (RawBytes . flip BS.replicate 0x43) chunkLengths)
+        annotate "no chunks should be emitted since all data fits" $ length emittedChunks `shouldBe` 0
 
-finalizationTests :: Test
+    prop "should not emit chunk when data exactly fills buffer, only after" $
+      forAll bufferFillingChunks $ \(bufferLength, chunkLengths) ->
+        do
+          machine <- mkMachine bufferLength ChunkFormatRaw
+          (machine', emittedChunks) <-
+            foldAppendChunks machine (map (RawBytes . flip BS.replicate 0x43) chunkLengths)
+          annotate "after appending exact fit data should not emit" $ length emittedChunks `shouldBe` 0
+          let oneByteData = RawBytes (BS.singleton 0x45)
+          (_machine, chunks') <- interpretCommand machine' (Append oneByteData)
+          case chunks' of
+            [chunk] -> do
+              chunkItemEntriesCount chunk `shouldBe` length chunkLengths
+              chunkItemFormat chunk `shouldBe` ChunkFormatRaw
+              (sizeofByteArray $ chunkItemData chunk) `shouldBe` (sum chunkLengths + 4 * length chunkLengths)
+            l -> length l `shouldBe` 1
+
+    prop "should emit one chunk when buffer is empty and data is oversized" $
+      \(Positive chunkDataLength) -> do
+        let bufferLength = chunkDataLength + 3
+        machine <- mkMachine bufferLength ChunkFormatRaw
+        let chunkData = RawBytes (BS.replicate chunkDataLength 0x46)
+        (_machine, chunks) <- interpretCommand machine (Append chunkData)
+        case chunks of
+          [oversizedChunk] -> do
+            -- Chunk should contain the oversized data
+            annotate "oversized chunk should have one entry" $ chunkItemEntriesCount oversizedChunk `shouldBe` 1
+            annotate "oversized chunk size should match input size" $ (sizeofByteArray $ chunkItemData oversizedChunk) `shouldBe` chunkDataLength + 4
+          l -> annotate "should emit one chunk" $ length l `shouldBe` 1
+
+    prop "shoud emit oversized chunk and buffer when buffer is not empty" $
+      forAll bufferFittingAndOversizedChunks $
+        \(bufferLength, smallDataLength, largeDataLength) -> do
+          machine <- mkMachine bufferLength ChunkFormatRaw
+          -- Add data that fits first
+          let smallData = RawBytes (BS.replicate smallDataLength 0x47)
+          (machine', chunks) <- interpretCommand machine (Append smallData)
+          annotate "after adding small data should not emit" $
+            length chunks `shouldBe` 0
+
+          -- Now add oversized data
+          let largeData = RawBytes (BS.replicate largeDataLength 0x48)
+          (_machine, chunks') <- interpretCommand machine' (Append largeData)
+          case chunks' of
+            [firstChunk, secondChunk] -> do
+              -- First chunk should contain the small data
+              annotate "first chunk should have correct entries count" $ chunkItemEntriesCount firstChunk `shouldBe` 1
+              annotate "first chunk data should match small input size" $ (sizeofByteArray $ chunkItemData firstChunk) `shouldBe` smallDataLength + 4
+              -- Second chunk should contain the large data
+              annotate "second chunk should have correct entries count" $ chunkItemEntriesCount secondChunk `shouldBe` 1
+              annotate "second chunk data should match large input size" $ (sizeofByteArray $ chunkItemData secondChunk) `shouldBe` largeDataLength + 4
+            l -> annotate "after adding oversized data should emit two chunks" $ length l `shouldBe` 2
+
+    it "should handle multiple boundary crossings correctly" $ do
+      let bufferLength = 50
+      machine <- mkMachine bufferLength ChunkFormatRaw
+      -- Add data that will cause multiple boundary crossings
+      -- 26 bytes total with prefix
+      let dataChunk1Length = 22
+      let dataChunk1 = RawBytes (BS.replicate dataChunk1Length 0x4A)
+      -- 14 bytes total with prefix
+      let dataChunk2Length = 10
+      let dataChunk2 = RawBytes (BS.replicate dataChunk2Length 0x4A)
+
+      (machine1, chunks1) <- interpretCommand machine (Append dataChunk1)
+      -- First add: 0 + 26 = 26, fits (total = 26)
+      annotate "first addition should not emit" $ length chunks1 `shouldBe` 0
+
+      (machine2, chunks2) <- interpretCommand machine1 (Append dataChunk1)
+      -- Second add: 26 + 26 = 52 > 50, so emit buffer with one entry (total = 26)
+      -- Start new buffer with new data (total = 26)
+      case chunks2 of
+        [chunk] -> do
+          annotate "second addition should emit one chunk with one entry" $ chunkItemEntriesCount chunk `shouldBe` 1
+          annotate "chunk data size should match" $ (sizeofByteArray $ chunkItemData chunk) `shouldBe` dataChunk1Length + 4
+        l -> annotate "second addition should emit one chunk" $ length l `shouldBe` 1
+
+      (machine3, chunks3) <- interpretCommand machine2 (Append dataChunk2)
+      -- Third add: 26 + 14 = 40, fits (total = 40)
+      annotate "third addition should not emit" $ length chunks3 `shouldBe` 0
+
+      (machine4, chunks4) <- interpretCommand machine3 (Append dataChunk2)
+      -- Fourth add: 40 + 14 = 54 > 50, so emit buffer with two entries (total = 40)
+      -- Start new buffer with new data (total = 14)
+      case chunks4 of
+        [chunk] -> do
+          annotate "fourth addition should emit one chunk with two entries" $ chunkItemEntriesCount chunk `shouldBe` 2
+          annotate "chunk data size should match" $ (sizeofByteArray $ chunkItemData chunk) `shouldBe` (dataChunk1Length + 4 + dataChunk2Length + 4)
+        l -> annotate "fourth addition should emit one chunk" $ length l `shouldBe` 1
+
+      (machine5, chunks5) <- interpretCommand machine4 (Append dataChunk2)
+      -- Fifth add: 14 + 14 = 28, fits (total = 28)
+      annotate "fifth addition should not emit" $ length chunks5 `shouldBe` 0
+
+      (machine6, chunks6) <- interpretCommand machine5 (Append dataChunk2)
+      -- Sixth add: 28 + 14 = 42, fits (total = 42)
+      annotate "sixth addition should not emit" $ length chunks6 `shouldBe` 0
+
+      (_digest, finalChunk) <- interpretCommand machine6 Finalize
+      case finalChunk of
+        Just chunk -> do
+          annotate "final chunk should have three entries" $ chunkItemEntriesCount chunk `shouldBe` 3
+          annotate "final chunk data size should match" $ (sizeofByteArray $ chunkItemData chunk) `shouldBe` (dataChunk2Length + 4) * 3
+        Nothing -> assertFailure "Expected final chunk on finalization"
+
+    prop "zero buffer length should always emit" $
+      \(Positive dataChunkLength) -> do
+        let bufferLength = 0
+        let dataChunk = RawBytes (BS.replicate dataChunkLength 0x4B)
+        machine <- mkMachine bufferLength ChunkFormatRaw
+        (_machine', chunks) <- interpretCommand machine (Append dataChunk)
+        case chunks of
+          [chunk] -> do
+            annotate "should emit one chunk with one entry" $ chunkItemEntriesCount chunk `shouldBe` 1
+            annotate "chunk data size should match" $ (sizeofByteArray $ chunkItemData chunk) `shouldBe` dataChunkLength + 4
+          l -> annotate "should emit two chunks" $ length l `shouldBe` 1
+
+finalizationTests :: Spec
 finalizationTests =
-  TestLabel "Finalization Tests" $
-    TestList
-      [ testFinalizeEmpty
-      , testFinalizeNonEmpty
-      ]
+  describe "Finalization Tests" $ do
+    prop "should not emit chunk when finalizing empty buffer" $
+      \(Positive bufferLength) -> do
+        machine <- mkMachine bufferLength ChunkFormatRaw
+        (digest, maybeChunk) <- interpretCommand machine Finalize
+        isNothing maybeChunk `shouldBe` True
+        -- Digest should still be computed (even if empty)
+        annotate "digest should be present" $ case digest of Digest _ -> True `shouldBe` True
 
-edgeCaseTests :: Test
-edgeCaseTests =
-  TestLabel "Edge Case Tests" $ TestList [testMultipleBoundaryCrossings]
+    prop "should emit fitting chunks only on finalize" $
+      forAll bufferFittingChunks $ \(bufferLength, chunkLengths) -> do
+        machine <- mkMachine bufferLength ChunkFormatRaw
+        (machine', chunks) <- foldAppendChunks machine (map (RawBytes . flip BS.replicate 0x49) chunkLengths)
+        annotate "should not emit chunks before finalization" $ (length chunks) `shouldBe` 0
 
--- Test adding data that fits within buffer capacity
-testFitsBuffer :: Test
-testFitsBuffer = TestCase $ do
-  let bufferLength = 100
-  machine <- mkMachine bufferLength ChunkFormatRaw
-  let smallData = RawBytes (BS.replicate 20 0x42)
-  (machine', chunks) <- interpretCommand machine (Append smallData)
-  assertEqual "Should not emit chunks when data fits" 0 (length chunks)
-
-  let mediumData = RawBytes (BS.replicate 30 0x43)
-  (_machine, chunks') <- interpretCommand machine' (Append mediumData)
-  assertEqual "Should not emit chunks when accumulated data fits" 0 (length chunks')
-
--- Test adding records that exactly fill the buffer
-testExactBoundary :: Test
-testExactBoundary = TestCase $ do
-  let bufferLength = 100
-  machine <- mkMachine bufferLength ChunkFormatRaw
-  let chunkDataLength = bufferLength - 4 -- 4 bytes for length prefix
-  let exactFitData = RawBytes (BS.replicate chunkDataLength 0x44)
-  (machine', chunks) <- interpretCommand machine (Append exactFitData)
-  assertEqual "Should not emit chunks when data exactly fits" 0 (length chunks)
-
-  -- Adding one more byte should trigger emission
-  let oneByte = RawBytes (BS.replicate 1 0x45)
-  (_machine, chunks') <- interpretCommand machine' (Append oneByte)
-  assertEqual "Should emit exactly one chunk" 1 (length chunks')
-  case chunks' of
-    [chunk] -> do
-      assertEqual "Chunk should have correct entries count" 1 (chunkItemEntriesCount chunk)
-      assertBool "Chunk should use correct format" (case chunkItemFormat chunk of ChunkFormatRaw -> True; _ -> False)
-      assertEqual "Chunk data should have correct size" (chunkDataLength + 4) (sizeofByteArray $ chunkItemData chunk)
-    _ -> assertFailure "Expected exactly one chunk"
-
--- Test adding a record larger than buffer when buffer is empty
-testOversizedEmpty :: Test
-testOversizedEmpty = TestCase $ do
-  let bufferLength = 50
-  machine <- mkMachine bufferLength ChunkFormatRaw
-  -- 50-3+4=51 bytes total with prefix, exceeding buffer
-  let largeDataLength = bufferLength - 3
-  let largeData = RawBytes (BS.replicate largeDataLength 0x46)
-  (_machine, chunks) <- interpretCommand machine (Append largeData)
-  -- In this case the implementation emits both the frozen buffer
-  -- (which is empty in this case) and the oversized chunk
-  -- TODO: consider changing this behavior to emit only the oversized chunk
-  assertEqual "Should emit exactly two chunks for oversized data" 2 (length chunks)
-  case chunks of
-    [emptyChunk, oversizedChunk] -> do
-      -- First chunk should be empty since buffer was empty
-      assertEqual "Empty chunk should have zero entries" 0 (chunkItemEntriesCount emptyChunk)
-      -- Second chunk should contain the oversized data
-      assertEqual "Oversized chunk should have correct entries count" 1 (chunkItemEntriesCount oversizedChunk)
-      assertEqual "Oversized chunk data should match input size" (largeDataLength + 4) (sizeofByteArray $ chunkItemData oversizedChunk)
-    _ -> assertFailure "Expected exactly two chunks"
-
--- Test adding a record larger than buffer when buffer is not empty
-testOversizedNonEmpty :: Test
-testOversizedNonEmpty = TestCase $ do
-  let bufferLength = 50
-  machine <- mkMachine bufferLength ChunkFormatRaw
-  -- Add data that fits first
-  let smallDataLength = bufferLength - 40
-  let smallData = RawBytes (BS.replicate smallDataLength 0x47)
-  (machine', chunks) <- interpretCommand machine (Append smallData)
-  assertEqual "Should not emit chunks for small data" 0 (length chunks)
-
-  -- Now add oversized data
-  -- 50-3+4=51 bytes total with prefix, exceeding buffer
-  let largeDataLength = bufferLength - 3
-  let largeData = RawBytes (BS.replicate largeDataLength 0x48)
-  (_machine, chunks') <- interpretCommand machine' (Append largeData)
-  assertEqual "Should emit exactly two chunks" 2 (length chunks')
-  case chunks' of
-    [firstChunk, secondChunk] -> do
-      -- First chunk should contain the small data
-      assertEqual "First chunk should have correct entries count" 1 (chunkItemEntriesCount firstChunk)
-      assertEqual "First chunk data should match small input size" (smallDataLength + 4) (sizeofByteArray $ chunkItemData firstChunk)
-      -- Second chunk should contain the large data
-      assertEqual "Second chunk should have correct entries count" 1 (chunkItemEntriesCount secondChunk)
-      assertEqual "Second chunk data should match large input size" (largeDataLength + 4) (sizeofByteArray $ chunkItemData secondChunk)
-    _ -> assertFailure "Expected exactly two chunks"
-
--- Test finalization when buffer is empty
-testFinalizeEmpty :: Test
-testFinalizeEmpty = TestCase $ do
-  let bufferLength = 10
-  machine <- mkMachine bufferLength ChunkFormatRaw
-  (digest, maybeChunk) <- interpretCommand machine Finalize
-  assertBool "Should not emit chunk for empty buffer" (isNothing maybeChunk)
-  -- Digest should still be computed (even if empty)
-  assertBool "Digest should be present" (case digest of Digest _ -> True)
-
--- Test finalization when buffer contains data
-testFinalizeNonEmpty :: Test
-testFinalizeNonEmpty = TestCase $ do
-  let bufferLength = 100
-  machine <- mkMachine bufferLength ChunkFormatRaw
-  let testDataLength = bufferLength - 30
-  let testData = RawBytes (BS.replicate testDataLength 0x49)
-  (machine', chunks) <- interpretCommand machine (Append testData)
-  assertEqual "Should not emit chunks before finalization" 0 (length chunks)
-
-  (_digest, maybeChunk) <- interpretCommand machine' Finalize
-  case maybeChunk of
-    Just chunk -> do
-      assertEqual "Finalized chunk should have correct entries count" 1 (chunkItemEntriesCount chunk)
-      assertBool "Finalized chunk should use correct format" (case chunkItemFormat chunk of ChunkFormatRaw -> True; _ -> False)
-      assertEqual "Finalized chunk data should have correct size" (testDataLength + 4) (sizeofByteArray $ chunkItemData chunk)
-    Nothing -> assertFailure "Expected chunk on finalization with data"
-
--- Test multiple boundary crossings
-testMultipleBoundaryCrossings :: Test
-testMultipleBoundaryCrossings = TestCase $ do
-  let bufferLength = 50
-  machine <- mkMachine bufferLength ChunkFormatRaw
-  -- Add data that will cause multiple boundary crossings
-  -- 26 bytes total with prefix
-  let dataChunk1Length = 22
-  let dataChunk1 = RawBytes (BS.replicate dataChunk1Length 0x4A)
-  -- 14 bytes total with prefix
-  let dataChunk2Length = 10
-  let dataChunk2 = RawBytes (BS.replicate dataChunk2Length 0x4A)
-
-  (machine1, chunks1) <- interpretCommand machine (Append dataChunk1)
-  -- First add: 0 + 26 = 26, fits (total = 26)
-  assertEqual "First addition should not emit" 0 (length chunks1)
-
-  (machine2, chunks2) <- interpretCommand machine1 (Append dataChunk1)
-  -- Second add: 26 + 26 = 52 > 50, so emit buffer with one entry (total = 26)
-  -- Start new buffer with new data (total = 26)
-  case chunks2 of
-    [chunk] -> do
-      assertEqual "Second addition should emit one chunk with one entry" 1 (chunkItemEntriesCount chunk)
-      assertEqual "Chunk data size should match" (dataChunk1Length + 4) (sizeofByteArray $ chunkItemData chunk)
-    l -> assertEqual "Second addition should emit one chunk" 1 (length l)
-
-  (machine3, chunks3) <- interpretCommand machine2 (Append dataChunk2)
-  -- Third add: 26 + 14 = 40, fits (total = 40)
-  assertEqual "Third addition should not emit" 0 (length chunks3)
-
-  (machine4, chunks4) <- interpretCommand machine3 (Append dataChunk2)
-  -- Fourth add: 40 + 14 = 54 > 50, so emit buffer with two entries (total = 40)
-  -- Start new buffer with new data (total = 14)
-  case chunks4 of
-    [chunk] -> do
-      assertEqual "Fourth addition should emit one chunk with two entries" 2 (chunkItemEntriesCount chunk)
-      assertEqual "Chunk data size should match" (dataChunk1Length + 4 + dataChunk2Length + 4) (sizeofByteArray $ chunkItemData chunk)
-    l -> assertEqual "Fourth addition should emit one chunk" 1 (length l)
-
-  (machine5, chunks5) <- interpretCommand machine4 (Append dataChunk2)
-  -- Fifth add: 14 + 14 = 28, fits (total = 28)
-  assertEqual "Fifth addition should not emit" 0 (length chunks5)
-
-  (machine6, chunks6) <- interpretCommand machine5 (Append dataChunk2)
-  -- Sixth add: 28 + 14 = 42, fits (total = 42)
-  assertEqual "Sixth addition should not emit" 0 (length chunks6)
-
-  (_digest, finalChunk) <- interpretCommand machine6 Finalize
-  case finalChunk of
-    Just chunk -> do
-      assertEqual "Final chunk should have three entries" 3 (chunkItemEntriesCount chunk)
-      assertEqual "Final chunk data size should match" ((dataChunk2Length + 4) * 3) (sizeofByteArray $ chunkItemData chunk)
-    Nothing -> assertFailure "Expected final chunk on finalization"
+        (_digest, maybeChunk) <- interpretCommand machine' Finalize
+        case maybeChunk of
+          Just chunk -> do
+            annotate "finalized chunk should have correct entries count" $ chunkItemEntriesCount chunk `shouldBe` length chunkLengths
+            annotate "finalized chunk should use correct format" $ chunkItemFormat chunk `shouldBe` ChunkFormatRaw
+            annotate "finalized chunk data should have correct size" $ (sizeofByteArray $ chunkItemData chunk) `shouldBe` (sum $ map (+ 4) chunkLengths)
+          Nothing -> assertFailure "Expected chunk on finalization with data"

--- a/scls-format/test/ChunksBuilderSpec.hs
+++ b/scls-format/test/ChunksBuilderSpec.hs
@@ -187,7 +187,7 @@ bufferBoundaryTests =
             [chunk] -> do
               annotate "should emit one chunk with one entry" $ chunkItemEntriesCount chunk `shouldBe` 1
               annotate "chunk data size should match" $ (sizeofByteArray $ chunkItemData chunk) `shouldBe` dataChunkLength + 4
-            l -> annotate "should emit two chunks" $ length l `shouldBe` 1
+            l -> annotate "should emit one chunk" $ length l `shouldBe` 1
 
 finalizationTests :: Spec
 finalizationTests =

--- a/scls-format/test/ChunksBuilderSpec.hs
+++ b/scls-format/test/ChunksBuilderSpec.hs
@@ -101,7 +101,7 @@ bufferBoundaryTests =
               annotate "oversized chunk size should match input size" $ (sizeofByteArray $ chunkItemData oversizedChunk) `shouldBe` chunkDataLength + 4
             l -> annotate "should emit one chunk" $ length l `shouldBe` 1
 
-    prop "shoud emit oversized chunk and buffer when buffer is not empty" $
+    prop "should emit oversized chunk and buffer when buffer is not empty" $
       forAll bufferFittingAndOversizedChunks $
         \(bufferLength, smallDataLength, largeDataLength) -> do
           machine <- mkMachine bufferLength ChunkFormatRaw

--- a/scls-format/test/Main.hs
+++ b/scls-format/test/Main.hs
@@ -32,16 +32,20 @@ import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import System.Random.Stateful (applyAtomicGen, globalStdGen)
 import Test.HUnit
+import Test.Hspec
+import Test.Hspec.Contrib.HUnit
 
 type SerializeF = FilePath -> NetworkId -> SlotNo -> Text -> S.Stream (S.Of RawBytes) IO () -> IO ()
 
 main :: IO ()
-main = runTestTTAndExit tests
+main = do
+  hspec $ do
+    fromHUnitTest tests
+    chunksBuilderTests
  where
   tests =
     TestList
       [ roundTriptests
-      , chunksBuilderTests
       -- basic tests: network encoding, slot encoding
       -- test hash of entire content
       -- test hash of each namespace

--- a/scls-format/test/Main.hs
+++ b/scls-format/test/Main.hs
@@ -8,6 +8,7 @@ import Cardano.SCLS.Internal.Serializer.MemPack
 import Cardano.SCLS.Internal.Serializer.Reference.Impl qualified as Reference (serialize)
 import Cardano.Types.Network (NetworkId (..))
 import Cardano.Types.SlotNo (SlotNo (..))
+import ChunksBuilderSpec (chunksBuilderTests)
 import Codec.CBOR.Cuddle.CBOR.Gen (generateCBORTerm')
 import Codec.CBOR.Cuddle.CDDL (CDDL, Name (..))
 import Codec.CBOR.Cuddle.CDDL.Resolve (
@@ -40,6 +41,7 @@ main = runTestTTAndExit tests
   tests =
     TestList
       [ roundTriptests
+      , chunksBuilderTests
       -- basic tests: network encoding, slot encoding
       -- test hash of entire content
       -- test hash of each namespace


### PR DESCRIPTION
This PR adds property-based and unit tests for `ChunksBuilder`.
`ChunksBuilder` implementation was also changed so that it doesn't emit an empty chunk when the buffer is empty and the we add data larger than the buffer size.