### PR TITLE
Add haddock documentation for the Merkle tree package

### DIFF
--- a/merkle-tree-incremental/merkle-tree-incremental.cabal
+++ b/merkle-tree-incremental/merkle-tree-incremental.cabal
@@ -54,7 +54,6 @@ test-suite merkle-tree-incremental-test
     test
 
   build-depends:
-    QuickCheck >=2.16.0,
     base >=4.7 && <5,
     bytestring >=0.12.0.0,
     crypton >=1.0.0,

--- a/merkle-tree-incremental/merkle-tree-incremental.cabal
+++ b/merkle-tree-incremental/merkle-tree-incremental.cabal
@@ -58,7 +58,9 @@ test-suite merkle-tree-incremental-test
     base >=4.7 && <5,
     bytestring >=0.12.0.0,
     crypton >=1.0.0,
+    hspec,
     merkle-tree,
     merkle-tree-incremental,
+    quickcheck-instances,
 
   default-language: GHC2021

--- a/merkle-tree-incremental/src/Crypto/Hash/MerkleTree/Incremental.hs
+++ b/merkle-tree-incremental/src/Crypto/Hash/MerkleTree/Incremental.hs
@@ -1,3 +1,49 @@
+{- |
+Module      : Crypto.Hash.MerkleTree.Incremental
+Description : Incremental construction of Merkle Trees
+Copyright   : (c) 2025 Modus Create, Inc.
+License     : Apache-2.0
+Maintainer  : cardano-cls@tweag.io
+Stability   : experimental
+
+This module provides functionality for constructing Merkle Trees incrementally,
+allowing you to build a tree by adding elements one at a time rather than
+requiring all elements upfront.
+
+== Overview
+
+The incremental approach is particularly useful when:
+
+* You need to compute a Merkle root as data arrives
+* Memory usage needs to be kept minimal
+* You want to avoid buffering all elements before tree construction
+
+== Algorithm
+
+The incremental construction maintains a state that represents partial subtrees
+at different levels. When a new element is added:
+
+1. It's hashed as a leaf node
+2. The algorithm attempts to join it with existing subtrees of the same level
+3. This process continues recursively, building up the tree from bottom to top
+
+== Usage Example
+
+@
+import Crypto.Hash.Algorithms (SHA3_256(..))
+import Crypto.Hash.MerkleTree.Incremental
+import Data.ByteString (pack)
+-- Create an empty tree state
+let state0 = empty SHA3_256
+-- Add elements incrementally
+let state1 = add state0 (pack [0x01, 0x02, 0x03])
+let state2 = add state1 (pack [0x04, 0x05, 0x06])
+let state3 = add state2 (pack [0x07, 0x08, 0x09])
+-- Finalize to get the complete tree
+let tree = finalize state3
+let rootHash = merkleRootHash tree
+@
+-}
 module Crypto.Hash.MerkleTree.Incremental (
   MerkleTree (..),
   MerkleTreeState,
@@ -17,22 +63,82 @@ import Data.ByteString.Char8 qualified as BC
 -- ----------------------------------------------------------------
 -- Merkle Tree and Hashes
 
+{- | Type alias for hash digests used in Merkle trees.
+
+This represents the result of applying a cryptographic hash function
+to some data. The type parameter @a@ specifies the hash algorithm used.
+-}
 type MerkleHash a = Digest a
 
+{- | Represents a completed Merkle tree.
+
+A Merkle tree can be in one of two states:
+
+* 'MerkleTreeEmpty': No elements have been added
+* 'MerkleTreeRoot': Contains the root hash of a non-empty tree
+
+This is the final result of the incremental construction process.
+Use 'merkleRootHash' to extract the root hash regardless of the state.
+-}
 data MerkleTree a
-  = MerkleTreeEmpty
-  | MerkleTreeRoot (MerkleHash a)
+  = -- | An empty tree with no elements
+    MerkleTreeEmpty
+  | -- | A tree with the given root hash
+    MerkleTreeRoot (MerkleHash a)
   deriving (Show, Eq)
 
-merkleRootHash :: forall a. (HashAlgorithm a) => MerkleTree a -> MerkleHash a
+{- | Extract the root hash from a completed Merkle tree.
+
+The root hash uniquely identifies the contents and structure of the tree.
+Trees with the same elements in the same order will have identical root hashes.
+-}
+merkleRootHash ::
+  forall a.
+  (HashAlgorithm a) =>
+  -- | The completed Merkle tree
+  MerkleTree a ->
+  {- | Returns the root hash of the tree:
+
+       * For an empty tree ('MerkleTreeEmpty'), returns the hash of an empty bytestring
+       * For a non-empty tree ('MerkleTreeRoot'), returns the stored root hash
+  -}
+  MerkleHash a
 merkleRootHash MerkleTreeEmpty = hash B.empty
 merkleRootHash (MerkleTreeRoot h) = h
 
--- | Hash function to use for merkle tree
+{- | Compute the hash for a leaf node (single element).
+
+This function creates a hash for leaf nodes by:
+
+1. Initializing a hash context
+2. Adding a prefix byte 0 to distinguish leaves from internal nodes
+3. Adding the element data
+4. Finalizing the hash
+
+The prefix byte ensures that leaf hashes are distinct from internal node
+hashes, preventing certain types of attacks on the tree structure.
+-}
 leafHash :: forall a b. (HashAlgorithm a, ByteArrayAccess b) => b -> MerkleHash a
 leafHash b =
   hashFinalize $ flip hashUpdate b $ hashUpdate hashInit $ B.singleton 0
 
+{- | Compute the hash for an internal node from two child hashes.
+
+This function creates a hash for internal nodes by:
+
+1. Initializing a hash context
+2. Adding a prefix byte 1 to distinguish internal nodes from leaves
+3. Adding the hexadecimal encoding of the first child hash
+4. Adding the hexadecimal encoding of the second child hash
+5. Finalizing the hash
+
+The order of arguments matters: @nodeHash left right ≠ nodeHash right left@.
+The first argument (@h1@) represents the left child, and the second (@h2@)
+represents the right child in the tree structure.
+
+The prefix byte (1) ensures that internal node hashes are distinct from
+leaf hashes, maintaining the integrity of the tree structure.
+-}
 nodeHash :: forall a. (HashAlgorithm a) => MerkleHash a -> MerkleHash a -> MerkleHash a
 nodeHash h1 h2 =
   hashFinalize $ flip hashUpdates [BC.pack (show h1), BC.pack (show h2)] $ hashUpdate hashInit $ B.singleton 1
@@ -40,27 +146,127 @@ nodeHash h1 h2 =
 -- ----------------------------------------------------------------
 -- Incremental Merkle Tree construction
 
+{- | State for incremental Merkle tree construction.
+
+This opaque type maintains the internal state during incremental tree
+construction. It represents a collection of partial subtrees at different
+levels that haven't been combined yet.
+
+The state is designed to be space-efficient, using O(log n) space where
+n is the number of elements added so far.
+
+Create with 'empty', add elements with 'add', and finalize with 'finalize'.
+-}
 newtype MerkleTreeState a = MerkleTreeState [MerkleTreeStateNode a]
 
+{- | Internal representation of a node in the incremental construction state.
+
+Each node represents a complete subtree at a specific level:
+
+* Level 0: Individual leaf nodes (single elements)
+* Level 1: Subtrees with 2 elements
+* Level 2: Subtrees with 4 elements
+* Level k: Subtrees with 2^k elements
+
+The incremental algorithm maintains at most one subtree per level,
+ensuring logarithmic space complexity.
+-}
 data MerkleTreeStateNode a = MerkleTreeStateNode
   { cLevel :: Int
+  -- ^ The level of this subtree (0 for leaves)
   , cHash :: MerkleHash a
+  -- ^ The root hash of this subtree
   }
   deriving (Show)
 
-empty :: (HashAlgorithm a) => a -> MerkleTreeState a
+{- | Create an empty Merkle tree construction state.
+
+This function initializes a new state for incremental tree construction.
+The hash algorithm type is used only to determine the type; the actual
+value is ignored.
+-}
+empty ::
+  (HashAlgorithm a) =>
+  -- | A value of the hash algorithm type (typically a constructor like 'Crypto.Hash.Algorithms.SHA256')
+  a ->
+  -- | An empty incremental Merkle tree state
+  MerkleTreeState a
 empty _ = MerkleTreeState []
 
-add :: (HashAlgorithm a, ByteArrayAccess b) => MerkleTreeState a -> b -> MerkleTreeState a
+{- | Add a new element to the incremental Merkle tree construction.
+
+This function adds a single element to the tree state. The element can be
+any type that implements 'ByteArrayAccess'.
+
+The algorithm works by:
+
+1. Hashing the new element as a leaf node
+2. Attempting to combine it with existing subtrees of the same level
+3. Recursively building up larger subtrees when possible
+-}
+add ::
+  (HashAlgorithm a, ByteArrayAccess b) =>
+  -- | The current tree construction state
+  MerkleTreeState a ->
+  -- | The element to add (must implement 'ByteArrayAccess')
+  b ->
+  -- | The updated tree construction state with the element incorporated
+  MerkleTreeState a
 add (MerkleTreeState state) bytes =
   join (MerkleTreeState (MerkleTreeStateNode{cLevel = 0, cHash = leafHash bytes} : state))
 
+{- | Combine adjacent subtrees of the same level in the construction state.
+
+This function implements the core of the incremental algorithm. It examines
+the construction state and combines any two adjacent subtrees that are at
+the same level.
+
+The process:
+
+1. Check if the first two subtrees have the same level
+2. If yes, combine them into a new subtree at level + 1
+3. Recursively apply the process to handle cascading combinations
+4. If no combination is possible, return the state unchanged
+
+The combination uses @nodeHash hash2 hash1@, which means the second subtree
+(older in insertion order) becomes the left child, and the first subtree
+(newer) becomes the right child. This maintains the correct tree structure
+for the incremental algorithm.
+
+Example state transitions:
+@
+[Level0(A)]                         -> [Level0(A)]                        (no change)
+[Level0(B), Level0(A)]              -> [Level1(nodeHash AB)]              (combine)
+[Level0(C), Level1(AB)]             -> [Level0(C), Level1(AB)]            (no change)
+[Level0(D), Level0(C), Level1(AB)]  -> [Level1(nodeHash C D), Level1(AB)] (combine)   -> [Level2(nodeHash AB CD)] (combine)
+@
+-}
 join :: (HashAlgorithm a) => MerkleTreeState a -> MerkleTreeState a
 join (MerkleTreeState ((MerkleTreeStateNode level1 hash1) : (MerkleTreeStateNode level2 hash2) : xs))
   | level1 == level2 = join (MerkleTreeState (MerkleTreeStateNode{cLevel = level1 + 1, cHash = nodeHash hash2 hash1} : xs))
 join state = state
 
-finalize :: (HashAlgorithm a) => MerkleTreeState a -> MerkleTree a
+{- | Convert an incremental construction state into a completed Merkle tree.
+
+This function finalizes the incremental construction process and produces
+a 'MerkleTree' that can be used to extract the root hash.
+
+The finalization process:
+
+1. If the state is empty, returns 'MerkleTreeEmpty'
+2. If there's only one subtree, that becomes the root
+3. If there are multiple subtrees, combines them by promoting smaller
+   subtrees to higher levels until only one remains
+
+__Note:__ You cannot add more elements to the resulting tree after
+finalization. If you need to add more elements, keep the state before calling 'finalize'.
+-}
+finalize ::
+  (HashAlgorithm a) =>
+  -- | The construction state to finalize
+  MerkleTreeState a ->
+  -- | The completed Merkle tree
+  MerkleTree a
 finalize (MerkleTreeState []) = MerkleTreeEmpty
 finalize (MerkleTreeState [MerkleTreeStateNode _ merkleHash]) =
   MerkleTreeRoot merkleHash

--- a/merkle-tree-incremental/src/Crypto/Hash/MerkleTree/Incremental.hs
+++ b/merkle-tree-incremental/src/Crypto/Hash/MerkleTree/Incremental.hs
@@ -3,7 +3,6 @@ module Crypto.Hash.MerkleTree.Incremental (
   MerkleTreeState,
   MerkleHash,
   merkleRootHash,
-  encodeMerkleHashHex,
   empty,
   add,
   finalize,
@@ -12,16 +11,13 @@ where
 
 import Crypto.Hash (Digest, HashAlgorithm, hash, hashFinalize, hashInit, hashUpdate, hashUpdates)
 import Data.ByteArray (ByteArrayAccess)
-import Data.ByteArray.Encoding qualified as BA
 import Data.ByteString qualified as B
+import Data.ByteString.Char8 qualified as BC
 
 -- ----------------------------------------------------------------
 -- Merkle Tree and Hashes
 
 type MerkleHash a = Digest a
-
-encodeMerkleHashHex :: (HashAlgorithm a) => MerkleHash a -> B.ByteString
-encodeMerkleHashHex = BA.convertToBase BA.Base16
 
 data MerkleTree a
   = MerkleTreeEmpty
@@ -39,7 +35,7 @@ leafHash b =
 
 nodeHash :: forall a. (HashAlgorithm a) => MerkleHash a -> MerkleHash a -> MerkleHash a
 nodeHash h1 h2 =
-  hashFinalize $ flip hashUpdates [encodeMerkleHashHex h1, encodeMerkleHashHex h2] $ hashUpdate hashInit $ B.singleton 1
+  hashFinalize $ flip hashUpdates [BC.pack (show h1), BC.pack (show h2)] $ hashUpdate hashInit $ B.singleton 1
 
 -- ----------------------------------------------------------------
 -- Incremental Merkle Tree construction

--- a/merkle-tree-incremental/test/Spec.hs
+++ b/merkle-tree-incremental/test/Spec.hs
@@ -1,19 +1,19 @@
-import Crypto.Hash.Algorithms (SHA3_256 (SHA3_256))
-import Crypto.Hash.MerkleTree (mkMerkleTree, mtHash)
-import Crypto.Hash.MerkleTree.Incremental (add, empty, encodeMerkleHashHex, finalize, merkleRootHash)
+import Crypto.Hash.Algorithms
+import Crypto.Hash.MerkleTree
+import Crypto.Hash.MerkleTree.Incremental
 import Data.ByteString.Char8 qualified as C
 
-import Test.QuickCheck
-
-prop_merkle_root_equal :: [String] -> Bool
-prop_merkle_root_equal entries =
-  (encodeMerkleHashHex $ merkleRootHash merkleTree1) == (mtHash merkleTree2)
- where
-  entries_bytes = map C.pack entries
-  state = foldl add (empty SHA3_256) entries_bytes
-  merkleTree1 = finalize state
-  merkleTree2 = mkMerkleTree entries_bytes
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck.Instances.ByteString ()
 
 main :: IO ()
 main = do
-  quickCheck prop_merkle_root_equal
+  hspec $
+    describe "Incremental Merkle Tree" $ do
+      prop "computed Merkle root hash should equal reference implementation one" $ do
+        \entries -> do
+          let state = foldl add (empty SHA3_256) entries
+              merkleTree1 = finalize state
+              merkleTree2 = mkMerkleTree entries
+          (C.pack $ show $ merkleRootHash merkleTree1) `shouldBe` (mtHash merkleTree2)

--- a/merkle-tree-incremental/test/Spec.hs
+++ b/merkle-tree-incremental/test/Spec.hs
@@ -1,6 +1,6 @@
-import Crypto.Hash.Algorithms
-import Crypto.Hash.MerkleTree
-import Crypto.Hash.MerkleTree.Incremental
+import Crypto.Hash.Algorithms (SHA3_256(..))
+import Crypto.Hash.MerkleTree (mkMerkleTree, mtHash)
+import Crypto.Hash.MerkleTree.Incremental (add, empty, finalize, merkleRootHash)
 import Data.ByteString.Char8 qualified as C
 
 import Test.Hspec


### PR DESCRIPTION
This PR adds documentation for the Merkle tree package, giving descriptions for the package as a whole, usage example, and descriptions for each element of it.
It was also identified that the `encodeMerkleHashHex` function had similar behaviour to the derived `show` function of `MerkleHash`, so it has been removed and replaced by the usage of `show`.
Test suite was refactored to use HSpec.