### PR TITLE
Loosen bytestring dependency

### DIFF
--- a/merkle-tree-incremental/merkle-tree-incremental.cabal
+++ b/merkle-tree-incremental/merkle-tree-incremental.cabal
@@ -34,7 +34,7 @@ library
 
   build-depends:
     base >=4.7 && <5,
-    bytestring >=0.12.0.0,
+    bytestring >=0.11.0.0,
     crypton >=1.0.0,
     memory >=0.18.0,
 
@@ -55,7 +55,7 @@ test-suite merkle-tree-incremental-test
 
   build-depends:
     base >=4.7 && <5,
-    bytestring >=0.12.0.0,
+    bytestring >=0.11.0.0,
     crypton >=1.0.0,
     hspec,
     merkle-tree,


### PR DESCRIPTION
Current dependency set in cardano-ledger is working with bytestring>=0.11.5 this commit loosenes restrictions of the version so merkle-tree-iterative can be used with it