### PR TITLE
Empty namespace serializer test and fix

### DIFF
--- a/scls-format/test/MultiNamespace.hs
+++ b/scls-format/test/MultiNamespace.hs
@@ -25,7 +25,6 @@ import Data.Traversable (for)
 import Streaming.Prelude qualified as S
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
-import Test.HUnit
 import Test.Hspec
 import Test.Hspec.Expectations.Contrib
 

--- a/scls-format/test/MultiNamespace.hs
+++ b/scls-format/test/MultiNamespace.hs
@@ -56,6 +56,17 @@ mkTestsFor serialize = do
       [ ("ns0", [BS8.pack (show (i :: Int)) | i <- [1 .. 2048]])
       , ("ns1", [BS8.pack (show (i :: Int)) | i <- [1 .. 2048]])
       ]
+  it "works for unordered streams" do
+    roundtrip
+      serialize
+      [ ("ns0", ["d", "a", "c", "b"])
+      , ("ns1", ["3", "1", "4", "2"])
+      , ("ns2", ["z", "x", "y"])
+      ]
+
+  it "handles empty namespaces correctly" do
+    let input = [("ns0", []), ("ns1", ["data"]), ("ns2", [])]
+    roundtrip serialize input
 
 type SerializeF = FilePath -> NetworkId -> SlotNo -> S.Stream (S.Of (InputChunk RawBytes)) IO () -> IO ()
 

--- a/scls-format/test/MultiNamespace.hs
+++ b/scls-format/test/MultiNamespace.hs
@@ -82,7 +82,7 @@ roundtrip serialize input = do
         mkStream
     nsps <- extractNamespaceList fileName
     annotate "Namespaces are as expected" do
-      (Map.keys nsData) `shouldBe` (sort nsps)
+      (sort nsps) `shouldBe` (Map.keys nsData)
 
     ns_digests <-
       for (Map.toList nsData) \(n, q) -> do

--- a/scls-format/test/MultiNamespace.hs
+++ b/scls-format/test/MultiNamespace.hs
@@ -80,10 +80,10 @@ roundtrip serialize input = do
           n
           ( \stream -> do
               decoded_data <- S.toList_ stream
-              assertEqual
+              annotate
                 (T.unpack n <> ": stream roundtrip successful")
-                (sort q)
-                [b | RawBytes b <- decoded_data]
+                $ [b | RawBytes b <- decoded_data]
+                  `shouldBe` (sort q)
           )
         fileDigest <- extractNamespaceHash n fileName
         expectedDigest <-


### PR DESCRIPTION
This PR adds a test case for streams with empty namespaces.
An issue was found in the external serializer in which it wouldn't include empty namespaces.
A fix for this issue is also included.