### PR TITLE
Loosen dependency restriction on text

### DIFF
--- a/scls-format/scls-format.cabal
+++ b/scls-format/scls-format.cabal
@@ -127,4 +127,4 @@ test-suite scls-format-test
     scls-format,
     streaming >=0.2.4.0,
     temporary,
-    text >=2.1,
+    text >=2.0,


### PR DESCRIPTION
Downstream packages require text 2.0 so we want to loosen the restriction, otherwise the downstream can build our package.