### PR TITLE
Strictify scls

### DIFF
--- a/scls-format/src/Cardano/SCLS/Internal/Record/Manifest.hs
+++ b/scls-format/src/Cardano/SCLS/Internal/Record/Manifest.hs
@@ -29,38 +29,38 @@ import Cardano.SCLS.Internal.Record.Internal.Class
 
 -- | Manifest summary information
 data ManifestSummary = ManifestSummary
-  { createdAt :: Text
+  { createdAt :: !Text
   -- ^ ISO 8601 date string
-  , tool :: Text
+  , tool :: !Text
   -- ^ tool info
-  , comment :: Maybe Text
+  , comment :: !(Maybe Text)
   -- ^ optional comment
   }
   deriving (Show)
 
 data NamespaceInfo = NamespaceInfo
-  { namespaceEntries :: Word64
+  { namespaceEntries :: {-# UNPACK #-} !Word64
   -- ^ number of entries
-  , namespaceChunks :: Word64
+  , namespaceChunks :: {-# UNPACK #-} !Word64
   -- ^ number of chunks
-  , namespaceHash :: Digest
+  , namespaceHash :: !Digest
   -- ^ multihash of root entry
   }
   deriving (Show)
 
 -- | Manifest record
 data Manifest = Manifest
-  { totalEntries :: Word64
+  { totalEntries :: !Word64
   -- ^ number of entries
-  , totalChunks :: Word64
+  , totalChunks :: !Word64
   -- ^ number of chunks
-  , rootHash :: Digest
+  , rootHash :: !Digest
   -- ^ multihash of root entry
-  , nsInfo :: Map Text NamespaceInfo
+  , nsInfo :: !(Map Text NamespaceInfo)
   -- ^ map from namespace to its entries, chunks and multihash
-  , prevManifestOffset :: Word64
+  , prevManifestOffset :: !Word64
   -- ^ offset of previous manifest
-  , summary :: ManifestSummary
+  , summary :: !ManifestSummary
   -- ^ summary information
   }
   deriving (Show)

--- a/scls-format/src/Cardano/SCLS/Internal/Serializer/ChunksBuilder/InMemory.hs
+++ b/scls-format/src/Cardano/SCLS/Internal/Serializer/ChunksBuilder/InMemory.hs
@@ -34,9 +34,9 @@ import Foreign.Ptr
 import Unsafe.Coerce (unsafeCoerce)
 
 data ChunkItem = ChunkItem
-  { chunkItemFormat :: ChunkFormat
-  , chunkItemData :: ByteArray
-  , chunkItemEntriesCount :: Int
+  { chunkItemFormat :: !ChunkFormat
+  , chunkItemData :: !ByteArray
+  , chunkItemEntriesCount :: !Int
   }
 
 -- | Command for the state machine

--- a/scls-format/src/Cardano/SCLS/Internal/Serializer/Reference/Dump.hs
+++ b/scls-format/src/Cardano/SCLS/Internal/Serializer/Reference/Dump.hs
@@ -120,7 +120,7 @@ constructChunks_ s0 = liftIO initialize >>= consume s0
     Stream (Of a) IO r ->
     BuilderMachine ->
     Stream (Of ChunkItem) IO (Digest)
-  consume s1 machine = do
+  consume s1 !machine = do
     case s1 of
       Return{} ->
         liftIO (interpretCommand machine Finalize) >>= \case
@@ -146,8 +146,8 @@ instance Monoid ManifestInfo where
 mkManifest :: ManifestInfo -> IO Manifest
 mkManifest (ManifestInfo namespaceInfo) = do
   let ns = Map.toList namespaceInfo
-      totalEntries = sum (namespaceEntries . snd <$> ns)
-      totalChunks = sum (namespaceChunks . snd <$> ns)
+      totalEntries = F.foldl' (+) 0 (namespaceEntries . snd <$> ns)
+      totalChunks = F.foldl' (+) 0 (namespaceChunks . snd <$> ns)
       rootHash =
         Digest $
           MT.merkleRootHash $


### PR DESCRIPTION
Strictify types and dumper to avoid potential space leaks.

All the changes are not strictly necessary here but with them we defence ourselves from compiler regressions or stupid bugs that one may make when working on a piece of code in isolation.