### PR TITLE
Add SCLS utility

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -2,4 +2,5 @@ packages:
   scls-format
   scls-cbor
   scls-cddl
+  scls-util
   merkle-tree-incremental

--- a/scls-format/src/Cardano/SCLS/Internal/Reader.hs
+++ b/scls-format/src/Cardano/SCLS/Internal/Reader.hs
@@ -5,6 +5,7 @@
 
 module Cardano.SCLS.Internal.Reader (
   withNamespacedData,
+  withLatestManifestFrame,
   extractRootHash,
   extractNamespaceList,
   extractNamespaceHash,

--- a/scls-util/LICENSE
+++ b/scls-util/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/scls-util/app/Main.hs
+++ b/scls-util/app/Main.hs
@@ -1,0 +1,212 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Main where
+
+import Cardano.SCLS.Internal.Hash (Digest (..))
+import Cardano.SCLS.Internal.Reader
+import Cardano.SCLS.Internal.Record.Manifest
+import Cardano.SCLS.Internal.Serializer.MemPack
+import Control.Exception (SomeException, catch)
+import Crypto.Hash (Blake2b_224)
+import Crypto.Hash.MerkleTree.Incremental qualified as MT
+import Data.Function ((&))
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as T
+import Options.Applicative
+import Streaming.Prelude qualified as S
+import System.Exit (ExitCode (..), exitWith)
+
+-- | Command-line options
+data Options = Options
+  { optCommand :: Command
+  }
+
+data Command
+  = Verify FilePath
+  | VerifyNamespace FilePath Text
+  | Info FilePath
+  | ListNamespaces FilePath
+
+parseOptions :: Parser Options
+parseOptions =
+  Options
+    <$> subparser
+      ( command
+          "verify"
+          ( info
+              (Verify <$> fileArg)
+              (progDesc "Verify root hash of chunks")
+          )
+          <> command
+            "verify-ns"
+            ( info
+                (VerifyNamespace <$> fileArg <*> namespaceArg)
+                (progDesc "Verify hash for a specific namespace")
+            )
+          <> command
+            "info"
+            ( info
+                (Info <$> fileArg)
+                (progDesc "Display SCLS file information")
+            )
+          <> command
+            "list-ns"
+            ( info
+                (ListNamespaces <$> fileArg)
+                (progDesc "List all namespaces in the file")
+            )
+      )
+ where
+  fileArg =
+    argument
+      str
+      (metavar "FILE" <> help "Path to SCLS file")
+  namespaceArg =
+    argument
+      str
+      (metavar "NAMESPACE" <> help "Namespace identifier")
+
+-- | Main entry point
+main :: IO ()
+main = do
+  opts <- execParser $ info (parseOptions <**> helper) fullDesc
+  result <- runCommand (optCommand opts)
+  exitWith $ toErrorCode result
+
+data Result
+  = Ok
+  | VerifyFailure -- TODO: add more detailed errors and mapping to exit codes
+  | OtherError
+
+toErrorCode :: Result -> ExitCode
+toErrorCode = \case
+  Ok -> ExitSuccess
+  VerifyFailure -> ExitFailure 65
+  OtherError -> ExitFailure 1
+
+-- | Execute the selected command
+runCommand :: Command -> IO Result
+runCommand = \case
+  Verify file -> verifyRoot file
+  VerifyNamespace file ns -> verifyNamespace file ns
+  Info file -> displayInfo file
+  ListNamespaces file -> listNamespaces file
+
+verifyRoot :: FilePath -> IO Result
+verifyRoot filePath = do
+  putStrLn $ "Verifying root hash for: " ++ filePath
+  catch
+    do
+      storedHash <- extractRootHash filePath
+      namespaces <- extractNamespaceList filePath
+      computedHash <- computeRootHash filePath namespaces
+
+      if storedHash == computedHash
+        then do
+          putStrLn "Root hash verification PASSED"
+          putStrLn $ "Hash: " ++ show storedHash
+          pure Ok
+        else do
+          putStrLn "Root hash verification FAILED"
+          putStrLn $ "Expected: " ++ show storedHash
+          putStrLn $ "Computed: " ++ show computedHash
+          pure VerifyFailure
+    \(e :: SomeException) -> do
+      putStrLn $ "Error: " ++ show e
+      pure OtherError
+
+computeRootHash :: FilePath -> [Text] -> IO Digest
+computeRootHash filePath namespaces = do
+  finalState <- foldl (combineNamespaceHash filePath) (pure $ MT.empty (undefined :: Blake2b_224)) namespaces
+  pure $ Digest $ MT.merkleRootHash $ MT.finalize finalState
+ where
+  combineNamespaceHash :: FilePath -> IO (MT.MerkleTreeState Blake2b_224) -> Text -> IO (MT.MerkleTreeState Blake2b_224)
+  combineNamespaceHash fp stateIO ns = do
+    state <- stateIO
+    nsHash <- computeNamespaceHash fp ns
+    pure $ MT.add state nsHash
+
+verifyNamespace :: FilePath -> Text -> IO Result
+verifyNamespace filePath namespace = do
+  putStrLn $ "Verifying hash for namespace: " ++ T.unpack namespace
+  catch
+    do
+      extractNamespaceHash namespace filePath >>= \case
+        Nothing -> do
+          putStrLn $ "Namespace not found"
+          pure VerifyFailure
+        Just storedHash -> do
+          computedHash <- computeNamespaceHash filePath namespace
+
+          if storedHash == computedHash
+            then do
+              putStrLn $ "Namespace hash verification PASSED"
+              putStrLn $ "Hash: " ++ show storedHash
+              pure Ok
+            else do
+              putStrLn $ "Namespace hash verification FAILED"
+              putStrLn $ "Expected: " ++ show storedHash
+              putStrLn $ "Computed: " ++ show computedHash
+              pure VerifyFailure
+    \(e :: SomeException) -> do
+      putStrLn $ "Error: " ++ show e
+      pure OtherError
+
+computeNamespaceHash :: FilePath -> Text -> IO Digest
+computeNamespaceHash filePath namespace = do
+  withNamespacedData filePath namespace \stream -> do
+    stream
+      & S.fold_
+        (\acc (RawBytes bs) -> MT.add acc bs)
+        (MT.empty undefined)
+        (Digest . MT.merkleRootHash . MT.finalize)
+
+displayInfo :: FilePath -> IO Result
+displayInfo filePath = do
+  putStrLn $ "File: " ++ filePath
+  catch
+    do
+      Manifest{..} <- withLatestManifestFrame pure filePath
+
+      putStrLn "\n=== File Information ==="
+      putStrLn $ "Root Hash: " ++ show rootHash
+      putStrLn $ "Total Entries: " ++ show totalEntries
+      putStrLn $ "Total Chunks: " ++ show totalChunks
+
+      putStrLn "\n=== Namespaces ==="
+      if null nsInfo
+        then putStrLn "(No namespaces)"
+        else do
+          mapM_
+            ( \(ns, NamespaceInfo{..}) -> do
+                putStrLn $ "\n" ++ T.unpack ns ++ ":"
+                putStrLn $ "  Hash: " ++ show namespaceHash
+                putStrLn $ "  Entries: " ++ show namespaceEntries
+                putStrLn $ "  Chunks: " ++ show namespaceChunks
+            )
+            $ Map.toList nsInfo
+
+      pure Ok
+    \(e :: SomeException) -> do
+      putStrLn $ "Error: " ++ show e
+      pure OtherError
+
+listNamespaces :: FilePath -> IO Result
+listNamespaces filePath = do
+  catch
+    do
+      namespaces <- extractNamespaceList filePath
+      if null namespaces
+        then putStrLn "No namespaces found"
+        else do
+          putStrLn "Namespaces:"
+          mapM_ (putStrLn . ("  - " <>) . T.unpack) namespaces
+      pure Ok
+    \(e :: SomeException) -> do
+      putStrLn $ "Error: " ++ show e
+      pure OtherError

--- a/scls-util/scls-util.cabal
+++ b/scls-util/scls-util.cabal
@@ -1,0 +1,53 @@
+cabal-version: 3.4
+name: scls-util
+version: 0.1.0.0
+synopsis: Utilities for interacting with SCLS files
+description:
+  A collection of command-line utilities for working with SCLS files.
+
+license: Apache-2.0
+license-file: LICENSE
+author: Tweag IO Team <cardano-cls@tweag.io>
+copyright: 2025 (c) Modus Create, Inc.
+category: Codec
+build-type: Simple
+
+common warnings
+  ghc-options: -Wall
+
+executable scls-util
+  import: warnings
+  hs-source-dirs: app
+  main-is: Main.hs
+  build-depends:
+    base >=4.18 && <5,
+    bytestring,
+    containers,
+    crypton,
+    merkle-tree-incremental,
+    optparse-applicative,
+    scls-format,
+    streaming,
+    text,
+
+  default-language: GHC2021
+
+test-suite scls-util-test
+  import: warnings
+  default-language: GHC2021
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is: Main.hs
+  build-depends:
+    base >=4.18 && <5,
+    bytestring,
+    containers,
+    crypton,
+    filepath,
+    hspec,
+    merkle-tree-incremental,
+    process,
+    scls-format,
+    streaming,
+    temporary,
+    text,

--- a/scls-util/test/Main.hs
+++ b/scls-util/test/Main.hs
@@ -1,0 +1,161 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Main (main) where
+
+import Cardano.SCLS.Internal.Reader (
+  extractNamespaceHash,
+  extractRootHash,
+ )
+import Cardano.SCLS.Internal.Serializer.MemPack (RawBytes (..))
+import Cardano.SCLS.Internal.Serializer.Reference.Impl qualified as Reference
+import Cardano.Types.Network (NetworkId (Mainnet))
+import Cardano.Types.SlotNo (SlotNo (SlotNo))
+import Control.Monad (forM_)
+import Data.ByteString.Char8 qualified as BS8
+import Data.Text (Text)
+import Data.Text qualified as T
+import Streaming.Prelude qualified as S
+import System.Exit (ExitCode (..))
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process (readProcessWithExitCode)
+import Test.Hspec
+
+main :: IO ()
+main = hspec $ do
+  describe "scls-util binary tests" do
+    verifyCommandTests
+    verifyNsCommandTests
+    infoCommandTests
+    listNsCommandTests
+
+generateTestFile :: FilePath -> IO (FilePath, [Text])
+generateTestFile dir = do
+  let fileName = dir </> "test.scls"
+      testData =
+        [ ("namespace1", [BS8.pack (show i) | i <- [1 :: Int .. 100]])
+        , ("namespace2", [BS8.pack (show i) | i <- [1 :: Int .. 50]])
+        , ("namespace3", [BS8.pack (show i) | i <- [1 :: Int .. 75]])
+        ]
+      mkStream =
+        S.each
+          [ ns S.:> S.each (map RawBytes entries)
+          | (ns, entries) <- testData
+          ]
+
+  _ <-
+    Reference.serialize @RawBytes
+      fileName
+      Mainnet
+      (SlotNo 1)
+      mkStream
+
+  return (fileName, map fst testData)
+
+runSclsUtil :: [String] -> IO (ExitCode, String, String)
+runSclsUtil args = do
+  readProcessWithExitCode "cabal" (["run", "scls-util", "--"] ++ args) ""
+
+verifyCommandTests :: Spec
+verifyCommandTests = describe "verify command" do
+  it "verifies a valid SCLS file" do
+    withSystemTempDirectory "scls-util-test-XXXXXX" \dir -> do
+      (fileName, _) <- generateTestFile dir
+      (exitCode, stdout, _) <- runSclsUtil ["verify", fileName]
+      h <- extractRootHash fileName
+
+      exitCode `shouldBe` ExitSuccess
+
+      stdout `shouldContain` (show h)
+
+  it "fails for non-existent file" do
+    (exitCode, _, _) <- runSclsUtil ["verify", "/nonexistent/file.scls"]
+
+    exitCode `shouldBe` ExitFailure 1
+
+verifyNsCommandTests :: Spec
+verifyNsCommandTests = describe "verify-ns command" do
+  it "verifies all namespaces correctly" do
+    withSystemTempDirectory "scls-util-test-XXXXXX" \dir -> do
+      (fileName, namespaces) <- generateTestFile dir
+
+      forM_ namespaces \ns -> do
+        (exitCode, stdout, _) <- runSclsUtil ["verify-ns", fileName, T.unpack ns]
+        Just h <- extractNamespaceHash ns fileName
+
+        exitCode `shouldBe` ExitSuccess
+
+        stdout `shouldContain` (show h)
+
+  it "fails for non-existent namespace" do
+    withSystemTempDirectory "scls-util-test-XXXXXX" \dir -> do
+      (fileName, _) <- generateTestFile dir
+      (exitCode, _, _) <- runSclsUtil ["verify-ns", fileName, "nonexistent"]
+
+      exitCode `shouldBe` ExitFailure 65
+
+infoCommandTests :: Spec
+infoCommandTests = describe "info command" do
+  it "displays file information" do
+    withSystemTempDirectory "scls-util-test-XXXXXX" \dir -> do
+      (fileName, _) <- generateTestFile dir
+      (exitCode, _, _) <- runSclsUtil ["info", fileName]
+
+      exitCode `shouldBe` ExitSuccess
+
+  it "lists all namespaces with their hashes" do
+    withSystemTempDirectory "scls-util-test-XXXXXX" \dir -> do
+      (fileName, namespaces) <- generateTestFile dir
+      (exitCode, stdout, _) <- runSclsUtil ["info", fileName]
+
+      exitCode `shouldBe` ExitSuccess
+
+      forM_ namespaces \ns -> do
+        stdout `shouldContain` T.unpack ns
+
+  it "fails for non-existent file" do
+    (exitCode, stdout, stderr) <- runSclsUtil ["info", "/nonexistent/file.scls"]
+
+    exitCode `shouldBe` ExitFailure 1
+
+    (stdout <> stderr) `shouldContain` "Error"
+
+listNsCommandTests :: Spec
+listNsCommandTests = describe "list-ns command" do
+  it "includes all expected namespaces" do
+    withSystemTempDirectory "scls-util-test-XXXXXX" \dir -> do
+      (fileName, expectedNamespaces) <- generateTestFile dir
+
+      (exitCode, stdout, _) <- runSclsUtil ["list-ns", fileName]
+
+      exitCode `shouldBe` ExitSuccess
+
+      forM_ expectedNamespaces \ns -> do
+        stdout `shouldContain` T.unpack ns
+
+  it "fails for non-existent file" do
+    (exitCode, stdout, stderr) <- runSclsUtil ["list-ns", "/nonexistent/file.scls"]
+
+    exitCode `shouldBe` ExitFailure 1
+
+    (stdout <> stderr) `shouldContain` "Error"
+
+  it "handles empty namespace list" do
+    withSystemTempDirectory "scls-util-test-XXXXXX" \dir -> do
+      let fileName = dir </> "empty.scls"
+      -- Create file with no namespaces
+      _ <-
+        Reference.serialize @RawBytes
+          fileName
+          Mainnet
+          (SlotNo 1)
+          (S.each [])
+
+      (exitCode, stdout, _) <- runSclsUtil ["list-ns", fileName]
+
+      exitCode `shouldBe` ExitSuccess
+
+      stdout `shouldContain` "No namespaces found"


### PR DESCRIPTION
Introduce a new utility package for interacting with SCLS files. So far it allows for verification of root hash, per-namespace hash verification, list namespaces, and displaying manifest info.
Next will be to integrate the ability to merge/split SCLS files.