### PR TITLE
Loosen requirements for serializer: only keys should be Ord

### DIFF
--- a/scls-format/src/Cardano/SCLS/Internal/Entry.hs
+++ b/scls-format/src/Cardano/SCLS/Internal/Entry.hs
@@ -25,7 +25,7 @@ data ChunkEntry k v = ChunkEntry
   }
   deriving (Show)
 
-instance (Eq k) => HasKey (ChunkEntry k v) where
+instance (Ord k) => HasKey (ChunkEntry k v) where
   type Key (ChunkEntry k v) = k
   getKey (ChunkEntry k _) = k
 

--- a/scls-format/src/Cardano/SCLS/Internal/Serializer/External/Impl.hs
+++ b/scls-format/src/Cardano/SCLS/Internal/Serializer/External/Impl.hs
@@ -88,7 +88,7 @@ so on, until we have placed a file.
 the size of the entries, but it can be changed without modifying the interface.
 -}
 prepareExternalSortNamespaced ::
-  (Typeable a, Ord (Key a), HasKey a, MemPack a) =>
+  (Typeable a, HasKey a, MemPack a) =>
   FilePath ->
   S.Stream (S.Of (InputChunk a)) IO () ->
   IO ()
@@ -115,7 +115,7 @@ the input may be unordered and we can have a namespaces to appear
 multiple times in the stream
 -}
 mergeChunks ::
-  (Ord (Key a), HasKey a) =>
+  (HasKey a) =>
   S.Stream (S.Of (InputChunk a)) IO () ->
   S.Stream (S.Of (Namespace, V.Vector a)) IO ()
 mergeChunks = loop Map.empty

--- a/scls-format/src/Cardano/SCLS/Internal/Serializer/HasKey.hs
+++ b/scls-format/src/Cardano/SCLS/Internal/Serializer/HasKey.hs
@@ -8,6 +8,6 @@ module Cardano.SCLS.Internal.Serializer.HasKey (
 import Data.Kind (Type)
 
 -- | Class for types that have an associated key.
-class (Eq (Key a)) => HasKey a where
+class (Ord (Key a)) => HasKey a where
   type Key a :: Type
   getKey :: a -> Key a

--- a/scls-format/src/Cardano/SCLS/Internal/Serializer/Reference/Impl.hs
+++ b/scls-format/src/Cardano/SCLS/Internal/Serializer/Reference/Impl.hs
@@ -31,7 +31,7 @@ import VectorBuilder.MVector qualified as Builder
 At this point it accepts values from one namespace only.
 -}
 serialize ::
-  (MemPack a, Ord (Key a), Typeable a, HasKey a, MemPackHeaderOffset a) =>
+  (MemPack a, Typeable a, HasKey a, MemPackHeaderOffset a) =>
   -- | path to resulting file
   FilePath ->
   -- | Network identifier
@@ -51,7 +51,7 @@ serialize resultFilePath network slotNo plan = do
             S.each [n S.:> S.each v | (n, v) <- Map.toList orderedStream]
         )
  where
-  mkVectors :: (Ord (Key a), HasKey a) => S.Stream (S.Of (InputChunk a)) IO () -> IO (Map Namespace (V.Vector a))
+  mkVectors :: (HasKey a) => S.Stream (S.Of (InputChunk a)) IO () -> IO (Map Namespace (V.Vector a))
   mkVectors = do
     S.foldM_
       do


### PR DESCRIPTION
Previously in a code we required entire value to have an Ord instance. While it's possible to have such one it leads to problems when we work with generic values of the types we do not know.

The other problem is that during the computation we should check the equality for the keys only and do not allow two values with the same key even if they are not equal. So the new type reflects that properly.