### PR TITLE
Fix CDDL for the utxo namespace

### DIFF
--- a/scls-cddl/cddl-src/Cardano/SCLS/CDDL.hs
+++ b/scls-cddl/cddl-src/Cardano/SCLS/CDDL.hs
@@ -24,6 +24,6 @@ data NamespaceInfo = NamespaceInfo
 namespaces :: Map.Map Text NamespaceInfo
 namespaces =
   Map.fromList
-    [ ("utxo/v0", NamespaceInfo (collectFromInit [HIRule UTxO.record_entry]) 38)
+    [ ("utxo/v0", NamespaceInfo (collectFromInit [HIRule UTxO.record_entry]) 34)
     , ("blocks/v0", NamespaceInfo (collectFromInit [HIRule Blocks.record_entry]) 32)
     ]

--- a/scls-cddl/cddl-src/Cardano/SCLS/Namespace/UTxO.hs
+++ b/scls-cddl/cddl-src/Cardano/SCLS/Namespace/UTxO.hs
@@ -39,7 +39,7 @@ babbage_tx_out =
         [ idx 0 ==> address
         , idx 1 ==> value
         , opt $ idx 2 ==> datum_option
-        , opt $ idx 3 ==> ("script_ref" =:= tag 24 (VBytes `cbor` script))
+        , opt $ idx 3 ==> ("script_ref" =:= script)
         ]
 
 plutus_data :: Rule


### PR DESCRIPTION
1. Fixes key size for the utxo/v0 namespace
2. Fixes script as it's stored as a raw cbor instead of encoding in the binary data