### PR TITLE
Add validate command to support scls-cddl

### DIFF
--- a/scls-cddl/cddl-validate/Cardano/SCLS/CDDL/Validate.hs
+++ b/scls-cddl/cddl-validate/Cardano/SCLS/CDDL/Validate.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE RecordWildCards #-}
+
+-- | Various helper functions for CBOR validation against supported CDDL specifications.
+module Cardano.SCLS.CDDL.Validate (
+  validateTermAgainst,
+  validateBytesAgainst,
+  invalidSpecs,
+) where
+
+import Cardano.SCLS.CDDL
+import Codec.CBOR.Cuddle.CBOR.Validator (CBORTermResult (..), validateTerm)
+import Codec.CBOR.Cuddle.CDDL (Name (..))
+import Codec.CBOR.Cuddle.CDDL.CTree (CTreeRoot' (..))
+import Codec.CBOR.Cuddle.CDDL.Resolve (
+  MonoRef,
+  NameResolutionFailure,
+  asMap,
+  buildMonoCTree,
+  buildRefCTree,
+  buildResolvedCTree,
+ )
+import Codec.CBOR.Cuddle.Huddle (toCDDL)
+import Codec.CBOR.Read qualified as CBOR
+import Codec.CBOR.Term (Term, decodeTerm)
+import Control.Monad.Trans.Reader (runReader)
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as BSL
+import Data.Functor ((<&>))
+import Data.Functor.Identity (Identity (..))
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+
+-- | Pre-compiled CDDL specifications for all supported namespaces.
+invalidSpecs :: Map.Map Text NameResolutionFailure
+validSpecs :: Map.Map Text (CTreeRoot' Identity Codec.CBOR.Cuddle.CDDL.Resolve.MonoRef)
+(invalidSpecs, validSpecs) = Map.mapEither
+  do
+    \NamespaceInfo{..} -> do
+      case buildMonoCTree =<< buildResolvedCTree (buildRefCTree $ asMap $ toCDDL namespaceSpec) of
+        Left e -> Left e
+        Right tree -> Right tree
+  do namespaces
+
+-- | Validate a parsed CBOR term against a rule in the namespace.
+validateTermAgainst :: Term -> Text -> Text -> Maybe CBORTermResult
+validateTermAgainst term namespace name =
+  let cddlName = Name name mempty
+   in Map.lookup namespace validSpecs >>= \cddl@(CTreeRoot cddlTree) ->
+        Map.lookup cddlName cddlTree <&> \rule ->
+          runReader (validateTerm term (runIdentity rule)) cddl
+
+-- | Validate raw bytes against a rule in the namespace.
+validateBytesAgainst :: ByteString -> Text -> Text -> Maybe CBORTermResult
+validateBytesAgainst bytes namespace name =
+  case CBOR.deserialiseFromBytes decodeTerm (BSL.fromStrict bytes) of
+    Left _ -> Nothing
+    Right (_, term) -> validateTermAgainst term namespace name

--- a/scls-cddl/scls-cddl.cabal
+++ b/scls-cddl/scls-cddl.cabal
@@ -43,6 +43,27 @@ library
 
   default-language: GHC2021
 
+library validate
+  import: warnings
+  visibility: public
+  exposed-modules:
+    Cardano.SCLS.CDDL.Validate
+
+  build-depends:
+    base >=4.18 && <5,
+    bytestring,
+    cborg,
+    containers,
+    cuddle >=0.5,
+    scls-cddl,
+    text,
+    transformers
+
+  hs-source-dirs:
+    cddl-validate
+
+  default-language: GHC2021
+
 executable gen-cddl
   import: warnings
   default-language: GHC2021
@@ -56,3 +77,15 @@ executable gen-cddl
     prettyprinter,
     scls-cddl,
     text
+
+test-suite scls-util-test
+  import: warnings
+  default-language: GHC2021
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is: Main.hs
+  build-depends:
+    base >=4.18 && <5,
+    containers,
+    hspec,
+    scls-cddl:{validate},

--- a/scls-cddl/test/Main.hs
+++ b/scls-cddl/test/Main.hs
@@ -1,0 +1,9 @@
+import Cardano.SCLS.CDDL.Validate
+import Data.Map.Strict qualified as Map
+import Test.Hspec
+
+main :: IO ()
+main = hspec $ do
+  describe "Basic checks" $ do
+    it "No invalid namespaces" $
+      invalidSpecs `shouldSatisfy` Map.null


### PR DESCRIPTION
We need to suport a way to easily validate parts of the data, otherwise it's terribly hard to search for the problems. So we add an additional commad that allows to do it