### PR TITLE
Change key size for the block namespace.

### DIFF
--- a/scls-cddl/cddl-src/Cardano/SCLS/CDDL.hs
+++ b/scls-cddl/cddl-src/Cardano/SCLS/CDDL.hs
@@ -25,5 +25,5 @@ namespaces :: Map.Map Text NamespaceInfo
 namespaces =
   Map.fromList
     [ ("utxo/v0", NamespaceInfo (collectFromInit [HIRule UTxO.record_entry]) 34)
-    , ("blocks/v0", NamespaceInfo (collectFromInit [HIRule Blocks.record_entry]) 32)
+    , ("blocks/v0", NamespaceInfo (collectFromInit [HIRule Blocks.record_entry]) 36) -- 28 bytes for key, and 8 for epoch in BE
     ]


### PR DESCRIPTION
We decided to keep epoch number in the key for the block/v0 so we can have a single namespace for the previous and current blocks