### PR TITLE
Fixes a bug when cddl-gen didn't work because of missing directory

### DIFF
--- a/scls-cddl/gen-cddl/Main.hs
+++ b/scls-cddl/gen-cddl/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Main where
 
@@ -11,6 +12,7 @@ import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 import Prettyprinter (pretty)
 import Prettyprinter.Render.Text (hPutDoc)
+import System.Directory (createDirectoryIfMissing)
 import System.Environment (getArgs)
 import System.FilePath ((<.>), (</>))
 import System.IO
@@ -18,8 +20,10 @@ import System.IO
 main :: IO ()
 main =
   getArgs >>= \case
-    [dir] -> forM_ (Map.toList namespaces) $ \(ns, NamespaceInfo{namespaceSpec = cddl}) -> do
-      writeSpec cddl (dir </> T.unpack ns <.> "cddl")
+    [dir] -> do
+      createDirectoryIfMissing True dir
+      forM_ (Map.toList namespaces) $ \(ns, NamespaceInfo{namespaceSpec = cddl}) -> do
+        writeSpec cddl (dir </> T.unpack (T.replace "/" "_" ns) <.> "cddl")
     _ -> error "Usage: gen-cddl directory"
 
 writeSpec :: Cuddle.Huddle -> FilePath -> IO ()

--- a/scls-cddl/scls-cddl.cabal
+++ b/scls-cddl/scls-cddl.cabal
@@ -73,6 +73,7 @@ executable gen-cddl
     base >=4.18 && <5,
     containers >=0.6,
     cuddle >=0.5,
+    directory >=1,
     filepath >=1.4,
     prettyprinter,
     scls-cddl,


### PR DESCRIPTION
Now cddl-gen create output directory if it's missing and excodes namespace names properly