### PR TITLE
Introduce pots namespace

### DIFF
--- a/scls-cddl/cddl-src/Cardano/SCLS/CDDL.hs
+++ b/scls-cddl/cddl-src/Cardano/SCLS/CDDL.hs
@@ -6,6 +6,7 @@ module Cardano.SCLS.CDDL (
 ) where
 
 import Cardano.SCLS.Namespace.Blocks qualified as Blocks
+import Cardano.SCLS.Namespace.Pots qualified as Pots
 import Cardano.SCLS.Namespace.UTxO qualified as UTxO
 import Codec.CBOR.Cuddle.Huddle (Huddle, HuddleItem (HIRule), collectFromInit)
 import Data.Map.Strict qualified as Map
@@ -26,4 +27,5 @@ namespaces =
   Map.fromList
     [ ("utxo/v0", NamespaceInfo (collectFromInit [HIRule UTxO.record_entry]) 34)
     , ("blocks/v0", NamespaceInfo (collectFromInit [HIRule Blocks.record_entry]) 36) -- 28 bytes for key, and 8 for epoch in BE
+    , ("pots/v0", NamespaceInfo (collectFromInit [HIRule Pots.record_entry]) 8) -- Key is epoch number
     ]

--- a/scls-cddl/cddl-src/Cardano/SCLS/Namespace/Pots.hs
+++ b/scls-cddl/cddl-src/Cardano/SCLS/Namespace/Pots.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Use camelCase" #-}
+
+module Cardano.SCLS.Namespace.Pots where
+
+import Cardano.SCLS.Common
+import Codec.CBOR.Cuddle.Huddle
+import Data.Function (($))
+import Text.Heredoc (str)
+
+-- | Top-level entry for pots namespace
+record_entry :: Rule
+record_entry = "record_entry" =:= pots_table
+
+-- | Table mapping pot names to coin values
+pots_table :: Rule
+pots_table =
+  comment
+    [str|Pots table containing the various accounting pots in Cardano
+        |
+        |Fields:
+        |  - treasury: coins in the treasury
+        |  - reserves: coins in the reserves
+        |  - deposit: total deposits held
+        |  - fee: accumulated fees
+        |  - donation: donations pot
+        |]
+    $ "pots_table"
+      =:= mp
+        [ "fee" ==> coin
+        , "deposit" ==> coin
+        , "donation" ==> coin
+        , "reserves" ==> coin
+        , "treasury" ==> coin
+        ]

--- a/scls-cddl/scls-cddl.cabal
+++ b/scls-cddl/scls-cddl.cabal
@@ -29,6 +29,7 @@ library
   other-modules:
     Cardano.SCLS.Common
     Cardano.SCLS.Namespace.Blocks
+    Cardano.SCLS.Namespace.Pots
     Cardano.SCLS.Namespace.UTxO
 
   build-depends:


### PR DESCRIPTION
Instead of introducing a key for a value in pots namespace we introduce a single entry per epoch no with all the interesting values.

As in current state on the wire we have only some keys we introduce versions for a namespace. It will help us to test versioning as well