### PR TITLE
Introduce snapshots namespace

### DIFF
--- a/scls-cddl/cddl-src/Cardano/SCLS/CDDL.hs
+++ b/scls-cddl/cddl-src/Cardano/SCLS/CDDL.hs
@@ -7,6 +7,7 @@ module Cardano.SCLS.CDDL (
 
 import Cardano.SCLS.Namespace.Blocks qualified as Blocks
 import Cardano.SCLS.Namespace.Pots qualified as Pots
+import Cardano.SCLS.Namespace.Snapshots qualified as Snapshots
 import Cardano.SCLS.Namespace.UTxO qualified as UTxO
 import Codec.CBOR.Cuddle.Huddle (Huddle, HuddleItem (HIRule), collectFromInit)
 import Data.Map.Strict qualified as Map
@@ -28,4 +29,5 @@ namespaces =
     [ ("utxo/v0", NamespaceInfo (collectFromInit [HIRule UTxO.record_entry]) 34)
     , ("blocks/v0", NamespaceInfo (collectFromInit [HIRule Blocks.record_entry]) 36) -- 28 bytes for key, and 8 for epoch in BE
     , ("pots/v0", NamespaceInfo (collectFromInit [HIRule Pots.record_entry]) 8) -- Key is epoch number
+    , ("snapshots/v0", NamespaceInfo (collectFromInit [HIRule Snapshots.record_entry]) 30)
     ]

--- a/scls-cddl/cddl-src/Cardano/SCLS/Common.hs
+++ b/scls-cddl/cddl-src/Cardano/SCLS/Common.hs
@@ -79,6 +79,9 @@ vkey = "vkey" =:= VBytes `sized` (32 :: Word64)
 vrf_vkey :: Rule
 vrf_vkey = "vrf_vkey" =:= VBytes `sized` (32 :: Word64)
 
+vrf_keyhash :: Rule
+vrf_keyhash = "vrf_keyhash" =:= hash32
+
 vrf_cert :: Rule
 vrf_cert = "vrf_cert" =:= arr [a VBytes, a (VBytes `sized` (80 :: Word64))]
 
@@ -131,3 +134,40 @@ bounded_bytes =
     $ "bounded_bytes"
       =:= VBytes
       `sized` (0 :: Word64, 64 :: Word64)
+
+url :: Rule
+url = "url" =:= VText `sized` (0 :: Word64, 128 :: Word64)
+
+dns_name :: Rule
+dns_name = "dns_name" =:= VText `sized` (0 :: Word64, 128 :: Word64)
+
+port :: Rule
+port = "port" =:= VUInt `le` 65535
+
+ipv4 :: Rule
+ipv4 = "ipv4" =:= VBytes `sized` (4 :: Word64)
+
+ipv6 :: Rule
+ipv6 = "ipv6" =:= VBytes `sized` (16 :: Word64)
+
+unit_interval :: Rule
+unit_interval =
+  comment
+    [str|NOTE: The real unit_interval is: #6.30([uint, uint])
+        |
+        | A unit interval is a number in the range between 0 and 1, which
+        | means there are two extra constraints:
+        |    1. numerator <= denominator
+        |    2. denominator > 0
+        |]
+    $ "unit_interval"
+      =:= tag
+        30
+        ( arr
+            [ a (VUInt `le` (maxBound :: Word64))
+            , a (VUInt `le` (maxBound :: Word64))
+            ]
+        )
+
+set :: (IsType0 t0) => t0 -> GRuleCall
+set = binding $ \x -> "set" =:= arr [0 <+ a x]

--- a/scls-cddl/cddl-src/Cardano/SCLS/Namespace/Snapshots.hs
+++ b/scls-cddl/cddl-src/Cardano/SCLS/Namespace/Snapshots.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Use camelCase" #-}
+module Cardano.SCLS.Namespace.Snapshots where
+
+import Cardano.SCLS.Common
+import Codec.CBOR.Cuddle.Huddle
+import Data.Word (Word64)
+import Text.Heredoc (str)
+import Prelude (($))
+
+record_entry :: Rule
+record_entry =
+  comment
+    [str| The key for the entry is one of the following:
+                |    ((credential / keyhash32) , (0 / 1 / 2))
+                |  where additional value stands for the value type:
+                |    - 0 : Coin value
+                |    - 1 : Keyhash of an delegation address
+                |    - 2 : Pool parameters
+                |
+                |  the size of the key is 30 bytes, (1 + 28 for tag and 1 for value type)
+                |]
+    $ "record_entry" =:= snapshot_out
+
+record_key :: Rule
+record_key =
+  "record_key"
+    =:= credential
+    / keyhash32
+
+pool_keyhash :: Rule
+pool_keyhash = "pool_keyhash" =:= hash28
+
+keyhash32 :: Rule
+keyhash32 = "keyhash" =:= hash32
+
+keyhash28 :: Rule
+keyhash28 = "keyhash" =:= hash28 -- Important: seems on the current chain it's 32
+
+addr_keyhash :: Rule
+addr_keyhash = "addr_keyhash" =:= hash28
+
+scripthash :: Rule
+scripthash =
+  comment
+    [str| To compute a script hash, note that you must prepend
+        | a tag to the bytes of the script before hashing.
+        | The tag is determined by the language.
+        | The tags in the Conway era are:
+        |  - "\x00" for multisig scripts
+        |  - "\x01" for Plutus V1 scripts
+        |  - "\x02" for Plutus V2 scripts
+        |  - "\x03" for Plutus V3 scripts
+    |]
+    $ "scripthash" =:= hash28
+
+credential :: Rule
+credential =
+  "credential"
+    =:= arr [0, a addr_keyhash]
+    / arr [1, a scripthash]
+
+snapshot_out :: Rule
+snapshot_out =
+  comment
+    [str| Value maybe be one of the following:
+         |  - Coin value
+         |  - Keyhash of an delegation address
+         |  - Pool parameters
+         |]
+    $ "snapshot_out"
+      =:= arr [0, a coin]
+      / arr [1, a keyhash28]
+      / arr [2, a pool_params]
+
+pool_params :: Rule
+pool_params =
+  "pool_params"
+    =:= mp
+      [ "cost" ==> coin
+      , "pledge" ==> coin
+      , "margin" ==> unit_interval
+      , "relays" ==> arr [0 <+ a relay]
+      , "operator" ==> pool_keyhash
+      , "pool_owners" ==> set addr_keyhash
+      , "vrf_keyhash" ==> vrf_keyhash
+      , "pool_metadata" ==> (pool_metadata / VNil)
+      , "reward_account" ==> reward_account
+      ]
+
+reward_account :: Rule
+reward_account =
+  "reward_account" =:= VBytes `sized` (29 :: Word64)
+
+--  =:= arr [0, a network_id, a keyhash32]
+
+network_id :: Rule
+network_id = "network_id" =:= int 0 / int 1
+
+relay :: Rule
+relay =
+  "relay"
+    =:= sarr [0, a single_host_addr]
+    / sarr [1, a single_host_name]
+    / sarr [2, a multi_host_name]
+
+single_host_addr :: Named Group
+single_host_addr =
+  comment [str| A single host address relay |] $
+    "single_host_addr"
+      =:~ grp
+        [ a (port / VNil)
+        , a (ipv4 / VNil)
+        , a (ipv6 / VNil)
+        ]
+
+single_host_name :: Named Group
+single_host_name =
+  "single_host_name"
+    =:~ grp [a (port / VNil), a dns_name]
+
+multi_host_name :: Named Group
+multi_host_name =
+  "multi_host_name" =:~ grp [a dns_name]
+
+pool_metadata :: Rule
+pool_metadata = "pool_metadata" =:= arr [a url, a pool_metadata_hash]
+
+pool_metadata_hash :: Rule
+pool_metadata_hash = "pool_metadata_hash" =:= hash32

--- a/scls-cddl/scls-cddl.cabal
+++ b/scls-cddl/scls-cddl.cabal
@@ -30,6 +30,7 @@ library
     Cardano.SCLS.Common
     Cardano.SCLS.Namespace.Blocks
     Cardano.SCLS.Namespace.Pots
+    Cardano.SCLS.Namespace.Snapshots
     Cardano.SCLS.Namespace.UTxO
 
   build-depends:


### PR DESCRIPTION
Introduce snapshot namespace by following CCDL in cardano-ledger specs. There are few minir differences to how encoding is described in the spec. For the sum-types tag is moved to the rule that describes variants and variants them-selves are described as a group without tag.