### PR TITLE
Introduce gov constituion namespace

### DIFF
--- a/scls-cddl/cddl-src/Cardano/SCLS/CDDL.hs
+++ b/scls-cddl/cddl-src/Cardano/SCLS/CDDL.hs
@@ -6,6 +6,7 @@ module Cardano.SCLS.CDDL (
 ) where
 
 import Cardano.SCLS.Namespace.Blocks qualified as Blocks
+import Cardano.SCLS.Namespace.GovConstitution qualified as GovConstitution
 import Cardano.SCLS.Namespace.GovPParams qualified as GovPParams
 import Cardano.SCLS.Namespace.Pots qualified as Pots
 import Cardano.SCLS.Namespace.Snapshots qualified as Snapshots
@@ -31,5 +32,6 @@ namespaces =
     , ("blocks/v0", NamespaceInfo (collectFromInit [HIRule Blocks.record_entry]) 36) -- 28 bytes for key, and 8 for epoch in BE
     , ("pots/v0", NamespaceInfo (collectFromInit [HIRule Pots.record_entry]) 8) -- Key is epoch number
     , ("snapshots/v0", NamespaceInfo (collectFromInit [HIRule Snapshots.record_entry]) 30)
+    , ("gov/constitution/v0", NamespaceInfo (collectFromInit [HIRule GovConstitution.record_entry]) 8)
     , ("gov/pparams/v0", NamespaceInfo (collectFromInit [HIRule GovPParams.record_entry]) 4)
     ]

--- a/scls-cddl/cddl-src/Cardano/SCLS/Common.hs
+++ b/scls-cddl/cddl-src/Cardano/SCLS/Common.hs
@@ -181,3 +181,17 @@ positive_int = "positive_int" =:= (1 :: Integer) ... maxWord64
 
 maxWord64 :: Integer
 maxWord64 = 18446744073709551615
+
+script_hash :: Rule
+script_hash =
+  comment
+    [str| To compute a script hash, note that you must prepend
+        | a tag to the bytes of the script before hashing.
+        | The tag is determined by the language.
+        | The tags in the Conway era are:
+        |  - "\x00" for multisig scripts
+        |  - "\x01" for Plutus V1 scripts
+        |  - "\x02" for Plutus V2 scripts
+        |  - "\x03" for Plutus V3 scripts
+    |]
+    $ "script_hash" =:= hash28

--- a/scls-cddl/cddl-src/Cardano/SCLS/Namespace/GovConstitution.hs
+++ b/scls-cddl/cddl-src/Cardano/SCLS/Namespace/GovConstitution.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+module Cardano.SCLS.Namespace.GovConstitution where
+
+import Cardano.SCLS.Common
+import Codec.CBOR.Cuddle.Huddle
+import Data.Function (($))
+import Text.Heredoc (str)
+
+record_entry :: Rule
+record_entry =
+  comment
+    [str| Constinution record entry
+        | Key is the epoch number (8 bytes)
+        |]
+    $ "record_entry" =:= constitution
+
+anchor :: Rule
+anchor =
+  "anchor"
+    =:= arr
+      [ "anchor_url" ==> url
+      , "anchor_data_hash" ==> hash32
+      ]
+
+constitution :: Rule
+constitution =
+  "constitution"
+    =:= arr
+      [ a anchor
+      , a (script_hash / VNil)
+      ]

--- a/scls-cddl/cddl-src/Cardano/SCLS/Namespace/Snapshots.hs
+++ b/scls-cddl/cddl-src/Cardano/SCLS/Namespace/Snapshots.hs
@@ -47,25 +47,11 @@ keyhash28 = "keyhash" =:= hash28 -- Important: seems on the current chain it's 3
 addr_keyhash :: Rule
 addr_keyhash = "addr_keyhash" =:= hash28
 
-scripthash :: Rule
-scripthash =
-  comment
-    [str| To compute a script hash, note that you must prepend
-        | a tag to the bytes of the script before hashing.
-        | The tag is determined by the language.
-        | The tags in the Conway era are:
-        |  - "\x00" for multisig scripts
-        |  - "\x01" for Plutus V1 scripts
-        |  - "\x02" for Plutus V2 scripts
-        |  - "\x03" for Plutus V3 scripts
-    |]
-    $ "scripthash" =:= hash28
-
 credential :: Rule
 credential =
   "credential"
     =:= arr [0, a addr_keyhash]
-    / arr [1, a scripthash]
+    / arr [1, a script_hash]
 
 snapshot_out :: Rule
 snapshot_out =

--- a/scls-cddl/scls-cddl.cabal
+++ b/scls-cddl/scls-cddl.cabal
@@ -29,6 +29,7 @@ library
   other-modules:
     Cardano.SCLS.Common
     Cardano.SCLS.Namespace.Blocks
+    Cardano.SCLS.Namespace.GovConstitution
     Cardano.SCLS.Namespace.GovPParams
     Cardano.SCLS.Namespace.Pots
     Cardano.SCLS.Namespace.Snapshots

--- a/scls-format/src/Cardano/SCLS/Internal/Entry.hs
+++ b/scls-format/src/Cardano/SCLS/Internal/Entry.hs
@@ -8,11 +8,13 @@ module Cardano.SCLS.Internal.Entry (
   GenericCBOREntry (..),
   SomeCBOREntry (..),
   sortByKey,
+  nubByKey,
 ) where
 
 import Cardano.SCLS.Internal.Serializer.HasKey
 import Cardano.SCLS.Internal.Serializer.MemPack (ByteStringSized (..), CBORTerm (..), MemPackHeaderOffset (..), SomeByteStringSized (..))
-import Data.List (sortOn)
+import Data.Function (on)
+import Data.List (nubBy, sortOn)
 import Data.MemPack
 import Data.MemPack.Buffer
 import Data.Typeable
@@ -107,3 +109,6 @@ instance HasKey SomeCBOREntry where
 
 sortByKey :: [SomeCBOREntry] -> [SomeCBOREntry]
 sortByKey = sortOn getKey
+
+nubByKey :: [SomeCBOREntry] -> [SomeCBOREntry]
+nubByKey = nubBy ((==) `on` getKey)

--- a/scls-format/test/Roundtrip.hs
+++ b/scls-format/test/Roundtrip.hs
@@ -65,7 +65,7 @@ mkRoundtripTestsFor groupName serialize =
         entries <-
           withSomeSNat kSize \(snat :: SNat n) -> do
             withKnownNat snat do
-              replicateM 1024 $ do
+              fmap nubByKey $ replicateM 1024 $ do
                 key <- uniformByteStringM (fromIntegral kSize) globalStdGen
                 term <- applyAtomicGen (generateCBORTerm' mt (Name (T.pack "record_entry") mempty)) globalStdGen
                 Right (_, canonicalTerm) <- pure $ deserialiseFromBytes decodeTerm $ toLazyByteString (encodeTerm term)


### PR DESCRIPTION
We had to introduce nubBy to the roundtrip tests, otherwise for the small keys there are not enough entries to generate expected input

Fixes #97 