### PR TITLE
Allow cuddle 0.3

### DIFF
--- a/scls-cddl/scls-cddl.cabal
+++ b/scls-cddl/scls-cddl.cabal
@@ -79,7 +79,7 @@ executable gen-cddl
   build-depends:
     base >=4.18 && <5,
     containers >=0.6,
-    cuddle >=0.5,
+    cuddle >=0.3,
     directory >=1,
     filepath >=1.4,
     prettyprinter,


### PR DESCRIPTION
Older version of the cardano-ledger required cuddle-0.3 so we allow it