### PR TITLE
Add mempack-1.0 packWord16beM function

### DIFF
--- a/scls-format/mempack-1.0/Data/MemPack/ByteOrdered.hs
+++ b/scls-format/mempack-1.0/Data/MemPack/ByteOrdered.hs
@@ -2,6 +2,7 @@
 module Data.MemPack.ByteOrdered (
   BigEndian (..),
   Storable (..),
+  packWord16beM,
   packWord32beM,
   packWord64beM,
   unpackBigEndianM,
@@ -44,6 +45,9 @@ instance (Bytes a, MemPack a) => MemPack (BigEndian a) where
 
 packBigEndianM :: (Bytes a, MemPack a) => a -> Pack s ()
 packBigEndianM = packM . BigEndian
+
+packWord16beM :: Word16 -> Pack s ()
+packWord16beM = packBigEndianM
 
 packWord32beM :: Word32 -> Pack s ()
 packWord32beM = packBigEndianM


### PR DESCRIPTION
Added missing function required for the old version of the cardano-ledger