### PR TITLE
Use text literal for the naming of the values.

### DIFF
--- a/scls-cbor/scls-cbor.cabal
+++ b/scls-cbor/scls-cbor.cabal
@@ -30,7 +30,6 @@ library
     bytestring,
     cborg,
     containers,
-    scls-format,
     text
 
   hs-source-dirs: src
@@ -55,4 +54,3 @@ test-suite scls-cbor-test
     hspec,
     quickcheck-instances,
     scls-cbor,
-    scls-format,

--- a/scls-cbor/src/Cardano/SCLS/CBOR/Canonical/Decoder.hs
+++ b/scls-cbor/src/Cardano/SCLS/CBOR/Canonical/Decoder.hs
@@ -3,7 +3,6 @@
 
 module Cardano.SCLS.CBOR.Canonical.Decoder where
 
-import Cardano.SCLS.Internal.Version (Version)
 import Codec.CBOR.ByteArray qualified as BA
 import Codec.CBOR.Decoding (Decoder)
 import Codec.CBOR.Decoding qualified as D
@@ -18,11 +17,12 @@ import Data.Sequence qualified as Seq
 import Data.Text qualified as T
 import Data.Word
 import GHC.Generics (Generic)
+import GHC.TypeLits
 
-newtype Versioned (v :: Version) a = Versioned {unVer :: a}
+newtype Versioned (ns :: Symbol) a = Versioned {unVer :: a}
   deriving (Eq, Generic, Ord, Bounded, Functor, Show)
 
-class FromCanonicalCBOR (v :: Version) a where
+class FromCanonicalCBOR (v :: Symbol) a where
   fromCanonicalCBOR :: Decoder s (Versioned v a)
 
 --------------------------------------------------------------------------------

--- a/scls-cbor/src/Cardano/SCLS/CBOR/Canonical/Encoder.hs
+++ b/scls-cbor/src/Cardano/SCLS/CBOR/Canonical/Encoder.hs
@@ -11,7 +11,6 @@ when defining the instances for specific types.
 -}
 module Cardano.SCLS.CBOR.Canonical.Encoder where
 
-import Cardano.SCLS.Internal.Version (Version)
 import Codec.CBOR.ByteArray.Sliced qualified as BAS
 import Codec.CBOR.Encoding (Encoding)
 import Codec.CBOR.Encoding qualified as E
@@ -25,9 +24,10 @@ import Data.List (sortOn)
 import Data.Map qualified as Map
 import Data.Sequence qualified as Seq
 import Data.Word
+import GHC.TypeLits
 
 -- | Encode data to CBOR corresponding with the SCLS format.
-class ToCanonicalCBOR (v :: Version) a where
+class ToCanonicalCBOR (v :: Symbol) a where
   -- | Encode to canonical CBOR at a given version
   toCanonicalCBOR :: proxy v -> a -> Encoding
 

--- a/scls-cbor/test/CanonicalSpec.hs
+++ b/scls-cbor/test/CanonicalSpec.hs
@@ -6,7 +6,6 @@ module CanonicalSpec (
 
 import Cardano.SCLS.CBOR.Canonical.Decoder (FromCanonicalCBOR (fromCanonicalCBOR), Versioned (Versioned))
 import Cardano.SCLS.CBOR.Canonical.Encoder (ToCanonicalCBOR (toCanonicalCBOR))
-import Cardano.SCLS.Internal.Version (Version (V1))
 import Codec.CBOR.Decoding (Decoder)
 import Codec.CBOR.Decoding qualified as D
 import Codec.CBOR.Read (deserialiseFromBytes)
@@ -30,7 +29,7 @@ import Test.QuickCheck.Instances.ByteString ()
 tests :: Spec
 tests =
   describe "Canonical CBOR encoding" do
-    let versions = [V1]
+    let versions = ["base/v0"]
     forM_
       versions
       ( \v ->

--- a/scls-format/scls-format.cabal
+++ b/scls-format/scls-format.cabal
@@ -82,6 +82,7 @@ library
     mtl,
     pqueue,
     primitive,
+    scls-cbor,
     scls-format:{mempack},
     streaming,
     temporary,

--- a/scls-format/src/Cardano/SCLS/Internal/Entry/ChunkEntry.hs
+++ b/scls-format/src/Cardano/SCLS/Internal/Entry/ChunkEntry.hs
@@ -12,7 +12,7 @@ module Cardano.SCLS.Internal.Entry.ChunkEntry (
 ) where
 
 import Cardano.SCLS.Internal.Entry.IsKey (IsKey (..))
-import Cardano.SCLS.Internal.NamespaceCodec (CanonicalCBOREntryDecoder (decodeEntry), CanonicalCBOREntryEncoder (encodeEntry), KnownNamespace (..), NamespaceKeySize, VersionedNS (VersionedNS), decodeKeyFromBytes, encodeKeyToBytes)
+import Cardano.SCLS.Internal.NamespaceCodec (CanonicalCBOREntryDecoder (decodeEntry), CanonicalCBOREntryEncoder (encodeEntry), KnownNamespace (..), NamespaceKeySize, Versioned (Versioned), decodeKeyFromBytes, encodeKeyToBytes)
 import Cardano.SCLS.Internal.Serializer.HasKey
 import Codec.CBOR.Read (deserialiseFromBytes)
 import Codec.CBOR.Write (toStrictByteString)
@@ -98,5 +98,5 @@ decodeChunkEntry _ (ChunkEntry (ByteStringSized k) (RawBytes v)) = do
   case (keyMaybe, valueEither) of
     (Nothing, _) -> Nothing
     (_, Left _) -> Nothing
-    (Just key, Right (_, VersionedNS value)) ->
+    (Just key, Right (_, Versioned value)) ->
       Just $ ChunkEntry key value

--- a/scls-format/test/NamespacedEncodingSpec.hs
+++ b/scls-format/test/NamespacedEncodingSpec.hs
@@ -10,7 +10,7 @@ associates data types with specific namespaces and versions.
 -}
 module NamespacedEncodingSpec where
 
-import Cardano.SCLS.Internal.NamespaceCodec (CanonicalCBOREntryDecoder (decodeEntry), CanonicalCBOREntryEncoder (encodeEntry), VersionedNS (VersionedNS))
+import Cardano.SCLS.Internal.NamespaceCodec (CanonicalCBOREntryDecoder (decodeEntry), CanonicalCBOREntryEncoder (encodeEntry), Versioned (Versioned))
 import Cardano.SCLS.Internal.Serializer.Dump.Plan (addNamespacedChunks, defaultSerializationPlan)
 import Codec.CBOR.Read (deserialiseFromBytes)
 import Codec.CBOR.Write
@@ -35,7 +35,7 @@ spec = do
 
       Right (_, decoded) <- pure $ deserialiseFromBytes (decodeEntry @"utxo/v0") $ toLazyByteString $ encodeEntry @"utxo/v0" val
 
-      decoded `shouldBe` (VersionedNS val)
+      decoded `shouldBe` (Versioned val)
 
   describe "SerializationPlan" $ do
     it "should accept chunks of different namespaces" $ do

--- a/scls-format/test/TestEntry.hs
+++ b/scls-format/test/TestEntry.hs
@@ -17,7 +17,7 @@ module TestEntry (
 
 import Cardano.SCLS.Internal.Entry.ChunkEntry (ChunkEntry (ChunkEntry))
 import Cardano.SCLS.Internal.Entry.IsKey (IsKey (keySize, packKeyM, unpackKeyM))
-import Cardano.SCLS.Internal.NamespaceCodec (CanonicalCBOREntryDecoder (decodeEntry), CanonicalCBOREntryEncoder (encodeEntry), KnownNamespace (NamespaceEntry, NamespaceKey), NamespaceKeySize, VersionedNS (VersionedNS), namespaceKeySize)
+import Cardano.SCLS.Internal.NamespaceCodec (CanonicalCBOREntryDecoder (decodeEntry), CanonicalCBOREntryEncoder (encodeEntry), KnownNamespace (NamespaceEntry, NamespaceKey), NamespaceKeySize, Versioned (Versioned), namespaceKeySize)
 import Cardano.SCLS.Internal.Serializer.HasKey (HasKey (Key, getKey))
 import Codec.CBOR.Decoding qualified as D
 import Codec.CBOR.Encoding qualified as E
@@ -97,7 +97,7 @@ instance CanonicalCBOREntryDecoder "utxo/v0" TestUTxO where
     D.decodeListLenOf 2
     key <- D.decodeBytes
     value <- D.decodeInt
-    pure $ VersionedNS $ TestUTxO $ TestEntry key value
+    pure $ Versioned $ TestUTxO $ TestEntry key value
 
 instance CanonicalCBOREntryEncoder "blocks/v0" TestBlock where
   -- For this test, we reuse the same data type (TestEntry), but we encode its value as `n+1`.
@@ -109,7 +109,7 @@ instance CanonicalCBOREntryDecoder "blocks/v0" TestBlock where
     D.decodeListLenOf 2
     key <- D.decodeBytes
     value <- D.decodeInt
-    pure $ VersionedNS $ TestBlock $ TestEntry key (value - 1)
+    pure $ Versioned $ TestBlock $ TestEntry key (value - 1)
 
 instance KnownNamespace "utxo/v0" where
   type NamespaceKey "utxo/v0" = TestUTxOKey


### PR DESCRIPTION
We need to keep the text version of the file contents encoding, leaving numeric version only for versions of the transport container.

This commit introduces the change.

After the change VersionedNS type becomes redundant, so it was dropped and we use only Versioned