### PR TITLE
Add text for canonical representation

### DIFF
--- a/scls-cbor/scls-cbor.cabal
+++ b/scls-cbor/scls-cbor.cabal
@@ -30,7 +30,7 @@ library
     bytestring,
     cborg,
     containers,
-    text
+    text,
 
   hs-source-dirs: src
   default-language: GHC2021
@@ -54,3 +54,4 @@ test-suite scls-cbor-test
     hspec,
     quickcheck-instances,
     scls-cbor,
+    text,

--- a/scls-cbor/src/Cardano/SCLS/CBOR/Canonical/Decoder.hs
+++ b/scls-cbor/src/Cardano/SCLS/CBOR/Canonical/Decoder.hs
@@ -89,6 +89,13 @@ instance FromCanonicalCBOR v SBS.ShortByteString where
     pure $ Versioned @v $ SBS.SBS ba
 
 --------------------------------------------------------------------------------
+-- Text
+--------------------------------------------------------------------------------
+
+instance FromCanonicalCBOR v T.Text where
+  fromCanonicalCBOR = Versioned @v <$> D.decodeStringCanonical
+
+--------------------------------------------------------------------------------
 -- Tuples
 --------------------------------------------------------------------------------
 

--- a/scls-cbor/src/Cardano/SCLS/CBOR/Canonical/Encoder.hs
+++ b/scls-cbor/src/Cardano/SCLS/CBOR/Canonical/Encoder.hs
@@ -23,6 +23,7 @@ import Data.Int
 import Data.List (sortOn)
 import Data.Map qualified as Map
 import Data.Sequence qualified as Seq
+import Data.Text (Text)
 import Data.Word
 import GHC.TypeLits
 
@@ -89,6 +90,13 @@ instance ToCanonicalCBOR v ByteString where
 instance ToCanonicalCBOR v SBS.ShortByteString where
   toCanonicalCBOR _ sbs@(SBS ba) =
     E.encodeByteArray $ BAS.SBA (Prim.ByteArray ba) 0 (SBS.length sbs)
+
+--------------------------------------------------------------------------------
+-- Text
+--------------------------------------------------------------------------------
+
+instance ToCanonicalCBOR v Text where
+  toCanonicalCBOR _ = E.encodeString
 
 --------------------------------------------------------------------------------
 -- Tuples


### PR DESCRIPTION
We need text values to be stored in the ledger state, so we need to add text instance.