### PR TITLE
Limit cuddle to <1.1.0

### DIFF
--- a/scls-cardano/scls-cardano.cabal
+++ b/scls-cardano/scls-cardano.cabal
@@ -41,7 +41,7 @@ library
   build-depends:
     base >=4.18 && <5,
     containers >=0.6,
-    cuddle >=0.3,
+    cuddle >=0.3 && <1.1.0,
     heredoc >=0.2,
     scls-core,
     text
@@ -62,7 +62,7 @@ library validate
     bytestring,
     cborg,
     containers,
-    cuddle >=0.3,
+    cuddle >=0.3 && <1.1.0,
     scls-cardano,
     text,
     transformers
@@ -102,7 +102,7 @@ executable gen-cddl
   build-depends:
     base >=4.18 && <5,
     containers >=0.6,
-    cuddle >=0.3,
+    cuddle >=0.3 && <1.1.0,
     directory >=1,
     filepath >=1.4,
     prettyprinter,

--- a/scls-format/scls-format.cabal
+++ b/scls-format/scls-format.cabal
@@ -111,7 +111,7 @@ test-suite scls-format-test
     bytestring,
     cborg >=0.2,
     containers,
-    cuddle >=0.3,
+    cuddle >=0.3 && <1.1.0,
     filepath,
     hspec,
     hspec-expectations,


### PR DESCRIPTION
Needs to be reverted and codebase updated once [cardano-ledger updates to the newer version](https://github.com/IntersectMBO/cardano-ledger/pull/5472). 