### PR TITLE
Refactor CBORTerm

### DIFF
--- a/mempack-scls/mempack-2.0/Data/MemPack/Extra.hs
+++ b/mempack-scls/mempack-2.0/Data/MemPack/Extra.hs
@@ -17,7 +17,8 @@ module Data.MemPack.Extra (
   Entry (..),
   ByteStringSized (..),
   SomeByteStringSized (..),
-  CBORTerm (..),
+  CBORTerm (getRawTerm),
+  mkCBORTerm,
   RawBytes (..),
   Unpack',
   hPutBuffer,
@@ -217,15 +218,18 @@ instance (KnownNat n) => MemPack (ByteStringSized n) where
     pure (ByteStringSized bs)
 
 -- | Helper to store CBOR terms directly as entries.
-newtype CBORTerm = CBORTerm CBOR.Term
+data CBORTerm = CBORTerm {getRawTerm :: !CBOR.Term, getEncodedBytes :: ByteString}
   deriving (Eq, Ord, Show)
 
-instance MemPack CBORTerm where
-  packedByteCount (CBORTerm t) =
-    BS.length (CBOR.toStrictByteString (CBOR.encodeTerm t))
+mkCBORTerm :: CBOR.Term -> CBORTerm
+mkCBORTerm t = CBORTerm t (CBOR.toStrictByteString (CBOR.encodeTerm t))
 
-  packM (CBORTerm t) =
-    packByteStringM (CBOR.toStrictByteString (CBOR.encodeTerm t))
+instance MemPack CBORTerm where
+  packedByteCount (CBORTerm _ bs) =
+    BS.length bs
+
+  packM (CBORTerm _ bs) =
+    packByteStringM bs
 
   unpackM = do
     start <- gets fromIntegral
@@ -234,7 +238,7 @@ instance MemPack CBORTerm where
       Left err -> failUnpack $ TextError $ "CBOR term deserialisation failed: " <> T.pack (show err)
       Right (_rest, bytesRead, term) -> do
         put (start + fromIntegral bytesRead)
-        pure (CBORTerm term)
+        pure (CBORTerm term bytes)
 
 hPutBuffer :: (Buffer u) => Handle -> u -> IO ()
 hPutBuffer handle u =

--- a/scls-format/test/Roundtrip.hs
+++ b/scls-format/test/Roundtrip.hs
@@ -111,7 +111,7 @@ mkRoundtripTestsFor groupName serialize =
                 key <- uniformByteStringM (fromIntegral kSize) globalStdGen
                 term <- applyAtomicGen (generateCBORTerm' mt (Name (T.pack "record_entry") mempty)) globalStdGen
                 Right (_, canonicalTerm) <- pure $ deserialiseFromBytes decodeTerm $ toLazyByteString (encodeTerm term)
-                pure $! SomeCBOREntry (GenericCBOREntry $ ChunkEntry (ByteStringSized @n key) (CBORTerm canonicalTerm))
+                pure $! SomeCBOREntry (GenericCBOREntry $ ChunkEntry (ByteStringSized @n key) (mkCBORTerm canonicalTerm))
         mEntries <-
           replicateM 1024 $ do
             MetadataEntry

--- a/scls-util/src/Cardano/SCLS/Util/Debug.hs
+++ b/scls-util/src/Cardano/SCLS/Util/Debug.hs
@@ -76,7 +76,7 @@ generateNamespaceEntries count spec = replicateM_ count do
   let size = fromSNat @n SNat
   keyIn <- liftIO $ uniformByteStringM (fromIntegral size) globalStdGen
   term <- liftIO $ applyAtomicGen (generateCBORTerm' spec (Name (T.pack "record_entry") mempty)) globalStdGen
-  S.yield $ GenericCBOREntry $ ChunkEntry (ByteStringSized @n keyIn) (CBORTerm term)
+  S.yield $ GenericCBOREntry $ ChunkEntry (ByteStringSized @n keyIn) (mkCBORTerm term)
 
 printHexEntries :: FilePath -> T.Text -> Int -> IO Result
 printHexEntries filePath ns_name@(Namespace.fromText -> ns) entryNo = do


### PR DESCRIPTION
Refactor the representation of CBORTerm to store both the raw term and its encoded bytes in order to avoid encoding the value multiple times when packing.