### PR TITLE
Update ghc versions used to build package

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.1
+            compilerKind: ghc
+            compilerVersion: 9.14.1
+            setup-method: ghcup
+            allow-failure: true
           - compiler: ghc-9.12.1
             compilerKind: ghc
             compilerVersion: 9.12.1
@@ -36,11 +41,6 @@ jobs:
           - compiler: ghc-9.10.2
             compilerKind: ghc
             compilerVersion: 9.10.2
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-9.8.4
-            compilerKind: ghc
-            compilerVersion: 9.8.4
             setup-method: ghcup
             allow-failure: false
       fail-fast: false
@@ -189,7 +189,41 @@ jobs:
           echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields -Werror=unused-packages -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project
           echo "package merkle-tree-incremental" >> cabal.project
           echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields -Werror=unused-packages -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project
+          # allow for ghc
           cat >> cabal.project <<EOF
+          -- Changes required for the ghc 9.14
+          allow-newer:
+            aeson-2.2.3.0:containers,
+            aeson-2.2.3.0:template-haskell,
+            aeson-2.2.3.0:time,
+            async-2.2.5:base,
+            boring-0.2.2:base,
+            cborg-0.2.10.0:base,
+            cborg-0.2.10.0:containers,
+            foldable1-classes-compat-0.1.2:base,
+            free-5.2:template-haskell,
+            indexed-traversable-0.1.4:base,
+            indexed-traversable-0.1.4:containers,
+            indexed-traversable-instances-0.1.2:base,
+            lens-5.3.5:template-haskell,
+            optics-core-0.4.1.1:containers,
+            ordered-containers-0.2.4:containers,
+            pqueue-1.6.0.0:base,
+            semialign-1.3.1:base,
+            semialign-1.3.1:containers,
+            text-iso8601-0.1.1:time,
+            these-1.2.1:base,
+            time-compat-1.9.8:base,
+            time-compat-1.9.8:time,
+            time-iso8601-0.1.1:time,
+            tree-diff-0.3.4:base,
+            tree-diff-0.3.4:containers,
+            tree-diff-0.3.4:time,
+            tree-diff-0.3.4:QuickCheck,
+            quickcheck-instances-0.3.33:base,
+            quickcheck-instances-0.3.33:containers,
+            quickcheck-instances-0.3.33:QuickCheck,
+            uuid-types-1.0.6:template-haskell,
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(scls-cardano|scls-core|scls-format|scls-cbor|mempack-scls|merkle-tree-incremental)$/; }' >> cabal.project.local
           cat cabal.project

--- a/cabal.project
+++ b/cabal.project
@@ -6,3 +6,37 @@ packages:
   scls-util
   mempack-scls
   merkle-tree-incremental
+
+-- Changes required for the ghc 9.14
+allow-newer:
+  aeson-2.2.3.0:containers,
+  aeson-2.2.3.0:template-haskell,
+  aeson-2.2.3.0:time,
+  async-2.2.5:base,
+  boring-0.2.2:base,
+  cborg-0.2.10.0:base,
+  cborg-0.2.10.0:containers,
+  foldable1-classes-compat-0.1.2:base,
+  free-5.2:template-haskell,
+  indexed-traversable-0.1.4:base,
+  indexed-traversable-0.1.4:containers,
+  indexed-traversable-instances-0.1.2:base,
+  lens-5.3.5:template-haskell,
+  optics-core-0.4.1.1:containers,
+  ordered-containers-0.2.4:containers,
+  pqueue-1.6.0.0:base,
+  semialign-1.3.1:base,
+  semialign-1.3.1:containers,
+  text-iso8601-0.1.1:time,
+  these-1.2.1:base,
+  time-compat-1.9.8:base,
+  time-compat-1.9.8:time,
+  time-iso8601-0.1.1:time,
+  tree-diff-0.3.4:base,
+  tree-diff-0.3.4:containers,
+  tree-diff-0.3.4:time,
+  tree-diff-0.3.4:QuickCheck,
+  quickcheck-instances-0.3.33:base,
+  quickcheck-instances-0.3.33:containers,
+  quickcheck-instances-0.3.33:QuickCheck,
+  uuid-types-1.0.6:template-haskell,

--- a/mempack-scls/mempack-scls.cabal
+++ b/mempack-scls/mempack-scls.cabal
@@ -15,6 +15,7 @@ copyright: 2025 (c) Modus Create, Inc.
 category: Codec
 build-type: Simple
 extra-doc-files: CHANGELOG.md
+tested-with: ghc ==9.14.1 || ==9.12.1 || ==9.10.2
 
 flag use-mempack-1
   description: Use the old mempack package

--- a/merkle-tree-incremental/merkle-tree-incremental.cabal
+++ b/merkle-tree-incremental/merkle-tree-incremental.cabal
@@ -10,6 +10,8 @@ build-type: Simple
 extra-source-files:
   README.md
 
+tested-with: ghc ==9.14.1 || ==9.12.1 || ==9.10.2
+
 common warnings
   ghc-options: -Wall
 

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -28,7 +28,6 @@ in {
         packages.scls-util.components.library.doCoverage = true;
         packages.merkle-tree-incremental.components.library.doCoverage = true;
       }];
-      ghc98.compiler-nix-name = "ghc98";
       ghc912.compiler-nix-name = "ghc912";
       ghc910-mempack-1 = {
         cabalProjectLocal = ''

--- a/scls-cardano/scls-cardano.cabal
+++ b/scls-cardano/scls-cardano.cabal
@@ -16,7 +16,7 @@ category: Data
 build-type: Simple
 extra-doc-files: CHANGELOG.md
 -- extra-source-files:
-tested-with: ghc ==9.12.1 || ==9.10.2 || ==9.8.4
+tested-with: ghc ==9.14.1 || ==9.12.1 || ==9.10.2
 
 common warnings
   ghc-options: -Wall

--- a/scls-cbor/scls-cbor.cabal
+++ b/scls-cbor/scls-cbor.cabal
@@ -12,6 +12,7 @@ maintainer: cardano-scls@tweag.io
 category: Data
 build-type: Simple
 extra-doc-files: CHANGELOG.md
+tested-with: ghc ==9.14.1 || ==9.12.1 || ==9.10.2
 
 -- extra-source-files:
 common warnings

--- a/scls-core/scls-core.cabal
+++ b/scls-core/scls-core.cabal
@@ -14,6 +14,7 @@ copyright: 2025 (c) Modus Create, Inc.
 category: Codec
 build-type: Simple
 extra-doc-files: CHANGELOG.md
+tested-with: ghc ==9.14.1 || ==9.12.1 || ==9.10.2
 
 common warnings
   ghc-options: -Wall

--- a/scls-format/scls-format.cabal
+++ b/scls-format/scls-format.cabal
@@ -13,6 +13,7 @@ copyright: 2025 (c) Modus Create, Inc.
 category: Codec
 build-type: Simple
 extra-doc-files: CHANGELOG.md
+tested-with: ghc ==9.14.1 || ==9.12.1 || ==9.10.2
 
 -- extra-source-files:
 common warnings

--- a/scls-format/src/Cardano/SCLS/Internal/Reader.hs
+++ b/scls-format/src/Cardano/SCLS/Internal/Reader.hs
@@ -110,7 +110,7 @@ extractNamespaceHash ns = withLatestManifestFrame \Manifest{..} ->
   pure (namespaceHash <$> Map.lookup ns nsInfo)
 
 data NotSCLSFile = NotSCLSFile
-  deriving (Show, Typeable, Exception)
+  deriving (Show, Exception)
 
 withLatestManifestFrame :: (Manifest -> IO r) -> FilePath -> IO r
 withLatestManifestFrame f filePath = do

--- a/scls-format/src/Cardano/SCLS/Internal/Serializer/Builder/InMemory.hs
+++ b/scls-format/src/Cardano/SCLS/Internal/Serializer/Builder/InMemory.hs
@@ -101,7 +101,7 @@ mkMachine bufferSize params = do
                   else do
                     frozenData <- freezeByteArrayPinned storage 0 offset
                     pure (final, Just (bMkItem params frozenData entriesCount))
-              Append @a input -> do
+              Append (input :: a) -> do
                 let entry = Entry $ bEncodeEntry @item params input
                 let l = packedByteCount entry
                 if offset + l <= bufferSize -- if we fit the current buffer we just need to write data and continue

--- a/scls-util/scls-util.cabal
+++ b/scls-util/scls-util.cabal
@@ -11,6 +11,7 @@ author: Tweag IO Team <cardano-cls@tweag.io>
 copyright: 2025 (c) Modus Create, Inc.
 category: Codec
 build-type: Simple
+tested-with: ghc ==9.14.1 || ==9.12.1 || ==9.10.2
 
 common warnings
   ghc-options: -Wall


### PR DESCRIPTION
1. Remove ghc-9.8 runner from haskell-ci and nix flakes
2. Add ghc-9.14 to haskell-ci (it's not on nixpkgs yet, so skipping that)