### PR TITLE
Add -Werror=unused-packages to GHC options

### DIFF
--- a/merkle-tree-incremental/merkle-tree-incremental.cabal
+++ b/merkle-tree-incremental/merkle-tree-incremental.cabal
@@ -13,7 +13,9 @@ extra-source-files:
 tested-with: ghc ==9.14.1 || ==9.12.1 || ==9.10.2
 
 common warnings
-  ghc-options: -Wall
+  ghc-options:
+    -Wall
+    -Werror=unused-packages
 
 library
   import: warnings

--- a/scls-cardano/scls-cardano.cabal
+++ b/scls-cardano/scls-cardano.cabal
@@ -19,7 +19,9 @@ extra-doc-files: CHANGELOG.md
 tested-with: ghc ==9.14.1 || ==9.12.1 || ==9.10.2
 
 common warnings
-  ghc-options: -Wall
+  ghc-options:
+    -Wall
+    -Werror=unused-packages
 
 library
   import: warnings

--- a/scls-cbor/scls-cbor.cabal
+++ b/scls-cbor/scls-cbor.cabal
@@ -16,7 +16,9 @@ tested-with: ghc ==9.14.1 || ==9.12.1 || ==9.10.2
 
 -- extra-source-files:
 common warnings
-  ghc-options: -Wall
+  ghc-options:
+    -Wall
+    -Werror=unused-packages
 
 library
   import: warnings

--- a/scls-format/scls-format.cabal
+++ b/scls-format/scls-format.cabal
@@ -17,7 +17,9 @@ tested-with: ghc ==9.14.1 || ==9.12.1 || ==9.10.2
 
 -- extra-source-files:
 common warnings
-  ghc-options: -Wall
+  ghc-options:
+    -Wall
+    -Werror=unused-packages
 
 library
   import: warnings

--- a/scls-util/scls-util.cabal
+++ b/scls-util/scls-util.cabal
@@ -14,7 +14,9 @@ build-type: Simple
 tested-with: ghc ==9.14.1 || ==9.12.1 || ==9.10.2
 
 common warnings
-  ghc-options: -Wall
+  ghc-options:
+    -Wall
+    -Werror=unused-packages
 
 library
   import: warnings


### PR DESCRIPTION
Include the `-Werror=unused-packages` flag in the GHC options across multiple cabal files to enforce stricter checks on unused packages during compilation (already done on CI).