### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -158,11 +158,11 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: source
       - name: checkout CIP
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: tweag/CIPs
           ref: 79ab917054f8398af4f81c0404b3a8bf698f06d5

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -24,14 +24,14 @@ jobs:
         runs-on: ${{ matrix.os }}
         steps:
         - name: git checkout
-          uses: actions/checkout@v3
+          uses: actions/checkout@v6
         - uses: cachix/install-nix-action@v31
           with:
             nix_path: nixpkgs=channel:nixos-unstable
             extra_nix_config: |
               experimental-features = nix-command flakes
               accept-flake-config = true
-        - uses: cachix/cachix-action@v15
+        - uses: cachix/cachix-action@v16
           with:
             name: tweag-cardano-cls
             authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"


### PR DESCRIPTION
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected:

- `actions/checkout@v3`
- `cachix/cachix-action@v15`

This PR upgrades the GitHub Actions workflows to utilize `checkout@v6` and `cachix-action@v16`.