### PR TITLE
Refactor gov/proposals/v0 namespace to include the proposals order

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -165,7 +165,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: tweag/CIPs
-          ref: d92300f9cf14f94a2bfab334e55a76cdf451fe8b
+          ref: 8b1b619bef7e11b37f21e2b39f3159ea5d48af23
           path: cips
       - name: set env for reference CDDL
         run: |

--- a/flake.lock
+++ b/flake.lock
@@ -69,17 +69,17 @@
     "cips": {
       "flake": false,
       "locked": {
-        "lastModified": 1778152917,
-        "narHash": "sha256-DhrwT5qnmmZyHV+0QT4oAcgTw35SJZILrJ/2ViDxlvs=",
+        "lastModified": 1778663000,
+        "narHash": "sha256-Oa5Jt6NXXf61BP5+N+LlF4cR8rSaSU2hX+nKfZ4JHhM=",
         "owner": "tweag",
         "repo": "CIPs",
-        "rev": "d92300f9cf14f94a2bfab334e55a76cdf451fe8b",
+        "rev": "8b1b619bef7e11b37f21e2b39f3159ea5d48af23",
         "type": "github"
       },
       "original": {
         "owner": "tweag",
         "repo": "CIPs",
-        "rev": "d92300f9cf14f94a2bfab334e55a76cdf451fe8b",
+        "rev": "8b1b619bef7e11b37f21e2b39f3159ea5d48af23",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
     inputs.nixpkgs.follows = "nixpkgs";
   };
   inputs.cips = {
-    url = "github:tweag/CIPs?rev=d92300f9cf14f94a2bfab334e55a76cdf451fe8b";
+    url = "github:tweag/CIPs?rev=8b1b619bef7e11b37f21e2b39f3159ea5d48af23";
     flake = false;
   };
   outputs = { self, nixpkgs, flake-utils, haskellNix, git-hooks, treefmt-nix

--- a/scls-cardano/cddl-src/Cardano/SCLS/CDDL.hs
+++ b/scls-cardano/cddl-src/Cardano/SCLS/CDDL.hs
@@ -122,5 +122,5 @@ type instance Spec.NamespaceKeySize "entities/stake_pools/vrf_key_hashes/v0" = 3
 type instance Spec.NamespaceKeySize "gov/committee/v0" = 8
 type instance Spec.NamespaceKeySize "gov/constitution/v0" = 8
 type instance Spec.NamespaceKeySize "gov/pparams/v0" = 4
-type instance Spec.NamespaceKeySize "gov/proposals/v0" = 34 -- 32 bytes txid+tx index + 2 bytes for proposal index
+type instance Spec.NamespaceKeySize "gov/proposals/v0" = 34 -- 28 bytes txid, 4 bytes tx index, 2 bytes for proposal index
 type instance Spec.NamespaceKeySize "gov/proposals/roots/v0" = 1 -- 1 byte for proposal purpose

--- a/scls-cardano/cddl-src/Cardano/SCLS/Namespace/GovProposals.hs
+++ b/scls-cardano/cddl-src/Cardano/SCLS/Namespace/GovProposals.hs
@@ -47,7 +47,7 @@ record_entry =
         | ```
         |
         |]
-    $ "record_entry" =:= proposal
+    $ "record_entry" =:= arr [a word64, a proposal]
 
 committee_cold_credential :: Rule
 committee_cold_credential = "committee_cold_credential" =:= credential


### PR DESCRIPTION
The order in which proposals were added must be preserved to properly reconstruct the ledger state.
This PR refactors the gov/proposals/v0 canonical namespace definition to also encode the order of each proposal.